### PR TITLE
Update ignore pattern and package metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
+*.tgz
 node_modules/
+yarn-error.log

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "registry": "https://registry.npmjs.org/",
     "access": "public"
   },
+  "files": [
+    "config/"
+  ],
   "scripts": {
     "test": "eslint ."
   },


### PR DESCRIPTION
This PR updates the package metadata and `.gitignore` file. The package now contains just the `config` directory and the required npm files:

```
tar tvf metamask-eslint-config-v1.0.0.tgz 
drwxr-xr-x  0 0      0           0 21 Jan 15:50 package
-rw-r--r--  0 0      0        1065 20 Jan 19:21 package/LICENSE
drwxr-xr-x  0 0      0           0 21 Jan 15:47 package/config
-rw-r--r--  0 0      0         855 21 Jan 15:50 package/package.json
-rw-r--r--  0 0      0        5169 21 Jan 15:47 package/config/index.js
-rw-r--r--  0 0      0        1697 21 Jan 15:47 package/config/jest.js
-rw-r--r--  0 0      0          51 21 Jan 15:47 package/config/nodejs.js
-rw-r--r--  0 0      0        2519 21 Jan 15:47 package/config/typescript.js
```