### PR TITLE
Disable Jest lowercase-name for describe blocks

### DIFF
--- a/config/jest.js
+++ b/config/jest.js
@@ -8,7 +8,7 @@ module.exports = {
   rules: {
     'jest/consistent-test-it': ['error', { 'fn': 'it' }],
     'jest/expect-expect': 'error',
-    'jest/lowercase-name': 'error',
+    'jest/lowercase-name': ['error', { 'ignore': ['describe'] }],
     'jest/no-alias-methods': 'error',
     'jest/no-commented-out-tests': 'error',
     'jest/no-disabled-tests': 'error',


### PR DESCRIPTION
This PR disables `jest/lowercase-name` for describe blocks. It is common for describe blocks to be the name of a class, e.g. `MetaMaskController`, and this previously disallowed that.