### PR TITLE
Enable core arrow-parens rule

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -6,6 +6,7 @@ module.exports = {
   rules: {
     'accessor-pairs': 'error',
     'arrow-spacing': ['error', { 'before': true, 'after': true }],
+    'arrow-parens': 'error',
     'block-spacing': ['error', 'always'],
     'brace-style': 'error',
     'camelcase': ['error', { 'properties': 'never', 'allow': ['^UNSAFE_'] }],


### PR DESCRIPTION
This PR enables the core ESLint `arrow-parens` rule, which enforces parentheses around arrow function parameters regardless of arity.<sup>[\[1\]][1]</sup> Requiring parentheses allows projects to introduce type annotations where needed with less noise.

This is a breaking change so it'll have to go in a major version bump.

  [1]:https://eslint.org/docs/rules/arrow-parens
