### PR TITLE
Enable core no-mixed-operators rule

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -60,6 +60,7 @@ module.exports = {
     'no-label-var': 'error',
     'no-labels': ['error', { 'allowLoop': false, 'allowSwitch': false }],
     'no-lone-blocks': 'error',
+    'no-mixed-operators': 'error',
     'no-mixed-spaces-and-tabs': 'error',
     'no-multi-spaces': 'error',
     'no-multi-str': 'error',


### PR DESCRIPTION
This PR enables the core ESLint `no-mixed-operators` rule, which errors when different operators are used consecutively without parentheses in an expression.<sup>[\[1\]][1]</sup> 

This is a breaking change so it'll have to go in a major version bump.

  [1]:https://eslint.org/docs/rules/no-mixed-operators
