### PR TITLE
Turn off `require-await` rule

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -257,7 +257,7 @@ module.exports = {
     'quotes': ['error', 'single', { 'avoidEscape': true, 'allowTemplateLiterals': true }],
     'radix': 'error',
     'require-atomic-updates': 'error',
-    'require-await': 'error',
+    'require-await': 'off',
     'require-jsdoc': 'off', // Deprecated in ESLint v5.10.0
     'require-unicode-regexp': 'error',
     'require-yield': 'error',


### PR DESCRIPTION
I don't think we should use this rule - mainly for the reasons outlined on the rule page itself; that using `async` is a useful shorthand for ensuring a function returns a Promise in all scenarios, particularly when an exception is thrown.

`async` also makes it very clear that a function returns a Promise, when it might otherwise be unclear at a glance because of uncertainty about what value is being `return`-ed.

There are some cases where we want to make a method `async` despite no asynchronous work being performed, just so that it conforms to an interface shared with other classes that _do_ need to be `async` (e.g. the keyrings).