### PR TITLE
Update CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Add base, TypeScript, and Jest configs (#3)
 
-[Unreleased]: https://github.com/MetaMask/eslint-config/compare/v2.1.0...HEAD
+[Unreleased]: https://github.com/MetaMask/eslint-config/compare/v2.1.1...HEAD
+[2.1.1]:https://github.com/MetaMask/eslint-config/compare/v2.1.0...v2.1.1
 [2.1.0]:https://github.com/MetaMask/eslint-config/compare/v2.0.0...v2.1.0
 [2.0.0]:https://github.com/MetaMask/eslint-config/compare/v1.2.0...v2.0.0
 [1.2.0]:https://github.com/MetaMask/eslint-config/compare/v1.1.0...v1.2.0


### PR DESCRIPTION
This PR updates the links in the `CHANGELOG.md` file to link to the correct tags, as of #38. That release was missing a tag, so I added that.