### PR TITLE
Relax no-plusplus rule

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -165,7 +165,7 @@ module.exports = {
     'no-octal-escape': 'error',
     'no-param-reassign': 'error',
     'no-path-concat': 'error',
-    'no-plusplus': ['error', { "allowForLoopAfterthoughts": true }],
+    'no-plusplus': ['error', { 'allowForLoopAfterthoughts': true }],
     'no-process-env': 'off',
     'no-process-exit': 'error',
     'no-proto': 'error',

--- a/config/index.js
+++ b/config/index.js
@@ -165,7 +165,7 @@ module.exports = {
     'no-octal-escape': 'error',
     'no-param-reassign': 'error',
     'no-path-concat': 'error',
-    'no-plusplus': 'error',
+    'no-plusplus': ['error', { "allowForLoopAfterthoughts": true }],
     'no-process-env': 'off',
     'no-process-exit': 'error',
     'no-proto': 'error',


### PR DESCRIPTION
This PR allows unary operators `++` and `--` in for loops.

See [`no-plusplus`](https://eslint.org/docs/rules/no-plusplus#options) options.