### PR TITLE
Set maximum consecutive empty lines to 1

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -149,7 +149,7 @@ module.exports = {
     'no-multi-assign': 'error',
     'no-multi-spaces': 'error',
     'no-multi-str': 'error',
-    'no-multiple-empty-lines': ['error', { 'max': 2 }],
+    'no-multiple-empty-lines': ['error', { 'max': 1 }],
     'no-native-reassign': 'error',
     'no-negated-condition': 'error',
     'no-negated-in-lhs': 'error',


### PR DESCRIPTION
I suggest that we set the maximum consecutive empty lines to 1. Currently it is set to 2, which is the default. The utility of this is unclear to me, and mostly it seems to introduce frustrating formatting inconsistencies in our code.