### PR TITLE
Disallow all anonymous default exports

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -302,7 +302,7 @@ module.exports = {
     'import/newline-after-import': 'error',
     'import/no-absolute-path': 'error',
     'import/no-amd': 'error',
-    'import/no-anonymous-default-export': ['error', { 'allowObject': true }],
+    'import/no-anonymous-default-export': 'error',
     'import/no-commonjs': 'off',
     'import/no-cycle': 'off',
     'import/no-default-export': 'off',


### PR DESCRIPTION
Refs https://github.com/MetaMask/metamask-extension/pull/8535

Closes #43

This PR disallows all anonymous default exports. From the docs for the ESLint rule, emphasis mine:<sup>[\[1\]][1]</sup>

> Reports if a module's default export is unnamed. This includes several types of unnamed data types; literals, object expressions, arrays, anonymous functions, arrow functions, and anonymous class declarations.
>
> **Ensuring that default exports are named helps improve the grepability of the codebase by encouraging the re-use of the same identifier for the module's default export at its declaration site and at its import sites.**

  [1]:https://github.com/benmosher/eslint-plugin-import/blob/v2.20.1/docs/rules/no-anonymous-default-export.md
