### PR TITLE
Disable prefer-object-spread

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -246,7 +246,7 @@ module.exports = {
     'prefer-exponentiation-operator': 'off',
     'prefer-named-capture-group': 'off',
     'prefer-numeric-literals': 'error',
-    'prefer-object-spread': 'error',
+    'prefer-object-spread': 'off', // Requires ES2018
     'prefer-promise-reject-errors': 'error',
     'prefer-reflect': 'off', // Deprecated in ESLint v3.9.0
     'prefer-regex-literals': 'error',


### PR DESCRIPTION
Closes #50

This disables `prefer-object-spread` as the rule presumes ES2018 which is a bit higher than some of the organization's projects currently support.