### PR TITLE
Relax prefer-destructuring rules

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -242,7 +242,22 @@ module.exports = {
     ],
     'prefer-arrow-callback': 'off',
     'prefer-const': 'error',
-    'prefer-destructuring': 'error',
+    'prefer-destructuring': [
+      'error',
+      {
+        'VariableDeclarator': {
+          'array': false,
+          'object': true,
+        },
+        'AssignmentExpression': {
+          'array': false,
+          'object': false,
+        },
+      },
+      {
+        'enforceForRenamedProperties': false,
+      },
+    ],
     'prefer-exponentiation-operator': 'off',
     'prefer-named-capture-group': 'off',
     'prefer-numeric-literals': 'error',


### PR DESCRIPTION
Refs MetaMask/metamask-extension#9263
Refs MetaMask/metamask-logo#35

This PR relaxes the [`prefer-destructuring`](https://eslint.org/docs/rules/prefer-destructuring) rule to no longer apply to arrays, object assignment, or renamed properties. That is, the following are allowed but not required:

```js
const first = array[0]; // before
const [first] = array; // after
```

```js
foo = obj.foo; // before
({ foo } = obj); // after
```

```js
const bar = obj.foo; // before
const { foo: bar } = obj; // afer
```