### PR TITLE
Migrate to eslint-plugin-node

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -18,7 +18,7 @@ module.exports = {
     'block-scoped-var': 'error',
     'block-spacing': ['error', 'always'],
     'brace-style': 'error',
-    'callback-return': 'error',
+    'callback-return': 'off', // Deprecated in ESLint v7.0.0
     'camelcase': ['error', { 'properties': 'never', 'allow': ['^UNSAFE_'] }],
     'capitalized-comments': 'off',
     'class-methods-use-this': 'off',
@@ -46,10 +46,10 @@ module.exports = {
     'function-paren-newline': ['error', 'consistent'],
     'generator-star-spacing': ['error', { 'before': true, 'after': true }],
     'getter-return': 'error',
-    'global-require': 'error',
+    'global-require': 'off',
     'grouped-accessor-pairs': 'error',
     'guard-for-in': 'error',
-    'handle-callback-err': ['error', '^(err|error)$'],
+    'handle-callback-err': 'off', // Deprecated in ESLint v7.0.0
     'id-blacklist': 'off',
     'id-length': 'off',
     'id-match': 'off',
@@ -144,7 +144,7 @@ module.exports = {
     'no-magic-numbers': 'off',
     'no-misleading-character-class': 'error',
     'no-mixed-operators': 'error',
-    'no-mixed-requires': 'error',
+    'no-mixed-requires': 'off', // Deprecated in ESLint v7.0.0
     'no-mixed-spaces-and-tabs': 'error',
     'no-multi-assign': 'error',
     'no-multi-spaces': 'error',
@@ -157,24 +157,24 @@ module.exports = {
     'no-new': 'error',
     'no-new-func': 'error',
     'no-new-object': 'error',
-    'no-new-require': 'error',
+    'no-new-require': 'off', // Deprecated in ESLint v7.0.0
     'no-new-symbol': 'error',
     'no-new-wrappers': 'error',
     'no-obj-calls': 'error',
     'no-octal': 'error',
     'no-octal-escape': 'error',
     'no-param-reassign': 'error',
-    'no-path-concat': 'error',
+    'no-path-concat': 'off', // Deprecated in ESLint v7.0.0
     'no-plusplus': ['error', { 'allowForLoopAfterthoughts': true }],
-    'no-process-env': 'off',
-    'no-process-exit': 'error',
+    'no-process-env': 'off', // Deprecated in ESLint v7.0.0
+    'no-process-exit': 'off', // Deprecated in ESLint v7.0.0
     'no-proto': 'error',
     'no-prototype-builtins': 'error',
     'no-redeclare': 'error',
     'no-regex-spaces': 'error',
     'no-restricted-globals': ['error', 'event'],
     'no-restricted-imports': 'off',
-    'no-restricted-modules': 'off',
+    'no-restricted-modules': 'off', // Deprecated in ESLint v7.0.0
     'no-restricted-properties': 'off',
     'no-restricted-syntax': 'off',
     'no-return-assign': ['error', 'except-parens'],
@@ -188,7 +188,7 @@ module.exports = {
     'no-shadow-restricted-names': 'error',
     'no-spaced-func': 'error',
     'no-sparse-arrays': 'error',
-    'no-sync': 'off',
+    'no-sync': 'off', // Deprecated in ESLint v7.0.0
     'no-tabs': 'error',
     'no-template-curly-in-string': 'error',
     'no-ternary': 'off',

--- a/config/nodejs.js
+++ b/config/nodejs.js
@@ -1,5 +1,52 @@
 module.exports = {
+  plugins: [
+    'node',
+  ],
   env: {
     node: true,
+  },
+  rules: {
+    // Possible Errors
+    'node/handle-callback-err': ['error', '^(err|error)$'],
+    'node/no-callback-literal': 'error',
+    'node/no-exports-assign': 'error',
+    'node/no-extraneous-import': 'error',
+    'node/no-extraneous-require': 'error',
+    'node/no-missing-import': 'error',
+    'node/no-missing-require': 'error',
+    'node/no-new-require': 'error',
+    'node/no-path-concat': 'error',
+    'node/no-process-exit': 'error',
+    'node/no-unpublished-bin': 'error',
+    'node/no-unpublished-import': 'error',
+    'node/no-unpublished-require': 'error',
+    'node/no-unsupported-features/es-builtins': 'error',
+    'node/no-unsupported-features/es-syntax': 'error',
+    'node/no-unsupported-features/node-builtins': 'error',
+    'node/process-exit-as-throw': 'error',
+    'node/shebang': 'error',
+
+    // "Best Practices"
+    'node/no-deprecated-api': 'error',
+
+    // Stylistic rules
+    'node/callback-return': 'error',
+    'node/exports-style': 'error',
+    'node/file-extension-in-import': 'error',
+    'node/global-require': 'error',
+    'node/no-mixed-requires': 'error',
+    'node/no-process-env': 'error',
+    'node/no-restricted-import': 'error',
+    'node/no-restricted-require': 'error',
+    'node/no-sync': 'error',
+    'node/prefer-global/buffer': 'error',
+    'node/prefer-global/console': 'error',
+    'node/prefer-global/process': 'error',
+    'node/prefer-global/text-decoder': 'error',
+    'node/prefer-global/text-encoder': 'error',
+    'node/prefer-global/url-search-params': 'error',
+    'node/prefer-global/url': 'error',
+    'node/prefer-promises/dns': 'error',
+    'node/prefer-promises/fs': 'error',
   },
 }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "eslint-plugin-import": "^2.20.1",
     "eslint-plugin-jest": "^23.6.0",
     "eslint-plugin-mocha": "^6.2.2",
+    "eslint-plugin-node": "^11.1.0",
     "typescript": "^3.7.5"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -355,6 +355,14 @@ eslint-module-utils@^2.4.1:
     debug "^2.6.9"
     pkg-dir "^2.0.0"
 
+eslint-plugin-es@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-es/-/eslint-plugin-es-3.0.1.tgz#75a7cdfdccddc0589934aeeb384175f221c57893"
+  integrity sha512-GUmAsJaN4Fc7Gbtl8uOBlayo2DqhwWvEzykMHSCZHU3XdJ+NSzzZcVhXh3VxX5icqQ+oQdIEawXX8xkR3mIFmQ==
+  dependencies:
+    eslint-utils "^2.0.0"
+    regexpp "^3.0.0"
+
 eslint-plugin-import@^2.20.1:
   version "2.20.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.20.1.tgz#802423196dcb11d9ce8435a5fc02a6d3b46939b3"
@@ -388,6 +396,18 @@ eslint-plugin-mocha@^6.2.2:
   dependencies:
     ramda "^0.26.1"
 
+eslint-plugin-node@^11.1.0:
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-node/-/eslint-plugin-node-11.1.0.tgz#c95544416ee4ada26740a30474eefc5402dc671d"
+  integrity sha512-oUwtPJ1W0SKD0Tr+wqu92c5xuCeQqB3hSCHasn/ZgjFdA9iDGNkNf2Zi9ztY7X+hNuMib23LNGRm6+uN+KLE3g==
+  dependencies:
+    eslint-plugin-es "^3.0.0"
+    eslint-utils "^2.0.0"
+    ignore "^5.1.1"
+    minimatch "^3.0.4"
+    resolve "^1.10.1"
+    semver "^6.1.0"
+
 eslint-scope@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.0.0.tgz#e87c8887c73e8d1ec84f1ca591645c358bfc8fb9"
@@ -400,6 +420,13 @@ eslint-utils@^1.4.3:
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-1.4.3.tgz#74fec7c54d0776b6f67e0251040b5806564e981f"
   integrity sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==
+  dependencies:
+    eslint-visitor-keys "^1.1.0"
+
+eslint-utils@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-2.1.0.tgz#d2de5e03424e707dc10c74068ddedae708741b27"
+  integrity sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==
   dependencies:
     eslint-visitor-keys "^1.1.0"
 
@@ -634,6 +661,11 @@ ignore@^4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
+
+ignore@^5.1.1:
+  version "5.1.8"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.8.tgz#f150a8b50a34289b33e22f5889abd4d8016f0e57"
+  integrity sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==
 
 import-fresh@^3.0.0:
   version "3.2.1"
@@ -1067,10 +1099,10 @@ resolve-from@^4.0.0:
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
   integrity sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==
 
-resolve@^1.10.0, resolve@^1.12.0, resolve@^1.13.1:
-  version "1.15.1"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.15.1.tgz#27bdcdeffeaf2d6244b95bb0f9f4b4653451f3e8"
-  integrity sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==
+resolve@^1.10.0, resolve@^1.10.1, resolve@^1.12.0, resolve@^1.13.1:
+  version "1.17.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.17.0.tgz#b25941b54968231cc2d1bb76a79cb7f2c0bf8444"
+  integrity sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==
   dependencies:
     path-parse "^1.0.6"
 
@@ -1113,7 +1145,7 @@ rxjs@^6.5.3:
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
 
-semver@^6.1.2, semver@^6.3.0:
+semver@^6.1.0, semver@^6.1.2, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==


### PR DESCRIPTION
Refs #46

This change disables deprecated core Node.js/CommonJS rules in favour of rules from eslint-plugin-node.

From the docs:<sup>[\[1\]][1]</sup>

> The ten Node.js/CommonJS rules in core have been deprecated and moved to the eslint-plugin-node plugin.

  [1]:https://eslint.org/docs/user-guide/migrating-to-7.0.0#deprecate-node-rules

All of the available eslint-plugin-node rules have been enabled.