### PR TITLE
Disable space-before-function-paren

### DIFF
--- a/config/typescript.js
+++ b/config/typescript.js
@@ -157,7 +157,14 @@ module.exports = {
     '@typescript-eslint/semi': ['error', 'always'],
     'semi': 'off',
 
-    '@typescript-eslint/space-before-function-paren': ['error', 'always'],
+    '@typescript-eslint/space-before-function-paren': [
+      'error',
+      {
+        'anonymous': 'always',
+        'named': 'never',
+        'asyncArrow': 'always',
+      },
+    ],
     'space-before-function-paren': 'off',
   },
 }


### PR DESCRIPTION
Closes #39

This PR changes [`space-before-function-paren`](https://eslint.org/docs/rules/space-before-function-paren) for TypeScript. There are examples of correct & incorrect code on the ESLint rule page.