### PR TITLE
Relax member-delimiter-style for TypeScript

### DIFF
--- a/config/typescript.js
+++ b/config/typescript.js
@@ -48,7 +48,7 @@ module.exports = {
       },
       'singleline': {
         'delimiter': 'semi',
-        'requireLast': true,
+        'requireLast': false,
       },
     }],
     '@typescript-eslint/member-ordering': 'off',


### PR DESCRIPTION
This PR relaxes `@typescript-eslint/member-delimiter-style`, allowing prettier to auto-format TypeScript sources.