### PR TITLE
Add `peerDependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,5 +32,9 @@
     "eslint-plugin-mocha": "^8.0.0",
     "eslint-plugin-node": "^11.1.0",
     "typescript": "^3.7.5"
+  },
+  "peerDependencies": {
+    "eslint": "^7.7.0",
+    "eslint-plugin-import": "^2.22.0"
   }
 }


### PR DESCRIPTION
The two packages that are required by all configurations (`eslint` and `eslint-plugin-import`) have been added as `peerDependencies`. This makes the installation process slightly less error prone.