### PR TITLE
Disable node/no-unsupported-features/es-syntax

### DIFF
--- a/config/nodejs.js
+++ b/config/nodejs.js
@@ -21,7 +21,7 @@ module.exports = {
     'node/no-unpublished-import': 'error',
     'node/no-unpublished-require': 'error',
     'node/no-unsupported-features/es-builtins': 'error',
-    'node/no-unsupported-features/es-syntax': 'error',
+    'node/no-unsupported-features/es-syntax': 'off',
     'node/no-unsupported-features/node-builtins': 'error',
     'node/process-exit-as-throw': 'error',
     'node/shebang': 'error',


### PR DESCRIPTION
Refs https://github.com/MetaMask/eslint-config/pull/64#issuecomment-712957969

This rule does not offer support for ES2015 import/export syntax (ESM) which is supported by many of the other rules. Ensuring no invalid syntax is used is best left to the build tools/runtime.