### PR TITLE
Disable node/file-extension-in-import

### DIFF
--- a/config/nodejs.js
+++ b/config/nodejs.js
@@ -32,7 +32,7 @@ module.exports = {
     // Stylistic rules
     'node/callback-return': 'error',
     'node/exports-style': 'error',
-    'node/file-extension-in-import': 'error',
+    'node/file-extension-in-import': 'off',
     'node/global-require': 'error',
     'node/no-mixed-requires': 'error',
     'node/no-process-env': 'error',


### PR DESCRIPTION
Refs https://github.com/MetaMask/eslint-config/pull/64#issuecomment-712959640

This rule is a duplicate of `import/extensions` as it only applies to ESM `import`s.