### PR TITLE
Disable node/no-missing-* rules

### DIFF
--- a/config/nodejs.js
+++ b/config/nodejs.js
@@ -12,8 +12,8 @@ module.exports = {
     'node/no-exports-assign': 'error',
     'node/no-extraneous-import': 'error',
     'node/no-extraneous-require': 'error',
-    'node/no-missing-import': 'error',
-    'node/no-missing-require': 'error',
+    'node/no-missing-import': 'off', // Duplicates `import/no-unresolved`
+    'node/no-missing-require': 'off', // Duplicates `import/no-unresolved`
     'node/no-new-require': 'error',
     'node/no-path-concat': 'error',
     'node/no-process-exit': 'error',


### PR DESCRIPTION
Closes #74

This change disables the `node/no-missing-import` and `node/no-missing-require` as they duplicate functionality from `import/no-unresolved`.