### PR TITLE
Make linebreak-style unix option explicit

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -60,7 +60,7 @@ module.exports = {
     'key-spacing': 'error',
     'keyword-spacing': ['error', { 'before': true, 'after': true }],
     'line-comment-position': 'off',
-    'linebreak-style': 'error',
+    'linebreak-style': ['error', 'unix'],
     'lines-around-comment': 'error',
     'lines-around-directive': 'off', // Deprecated in in ESLint v4.0.0
     'lines-between-class-members': 'error',


### PR DESCRIPTION
Allegedly, the `eslint` default is Unix, but recent behavior of `eslint` on @NiranjanaBinoy's Windows machine made me doubt whether that's true. Either way, can't hurt to make the alleged default explicit!

Rule source: https://eslint.org/docs/rules/linebreak-style