### PR TITLE
Add prettier to base config

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,26 @@
 module.exports = {
   root: true,
 
+  parserOptions: {
+    ecmaVersion: 2017,
+  },
+
   extends: ['@metamask/eslint-config', '@metamask/eslint-config-nodejs'],
+
+  overrides: [
+    {
+      files: ['./scripts/*.js'],
+      parserOptions: {
+        sourceType: 'script',
+      },
+      rules: {
+        'import/no-dynamic-require': 'off',
+        'node/global-require': 'off',
+        'node/no-sync': 'off',
+        'node/no-unpublished-require': 'off',
+      },
+    },
+  ],
+
+  ignorePatterns: ['!.eslintrc.js'],
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,8 +1,5 @@
 module.exports = {
   root: true,
 
-  extends: [
-    '@metamask/eslint-config',
-    '@metamask/eslint-config-nodejs',
-  ],
+  extends: ['@metamask/eslint-config', '@metamask/eslint-config-nodejs'],
 };

--- a/package.json
+++ b/package.json
@@ -5,13 +5,16 @@
     "node": ">=12.0.0"
   },
   "scripts": {
-    "lint": "yarn eslint . --ext ts,js",
-    "lint:fix": "yarn lint --fix"
+    "lint:eslint": "yarn eslint . --ext ts,js",
+    "lint:rules": "node ./scripts/validate-prettier-rules.js",
+    "lint": "yarn lint:eslint && yarn lint:rules",
+    "lint:fix": "yarn lint:eslint --fix && yarn lint:rules"
   },
   "workspaces": [
     "packages/*"
   ],
   "devDependencies": {
+    "eslint-config-prettier": "^8.1.0",
     "lerna": "^4.0.0"
   }
 }

--- a/packages/base/README.md
+++ b/packages/base/README.md
@@ -13,11 +13,15 @@ yarn add --dev \
     @metamask/eslint-config@^5.0.0
 ```
 
-List `@metamask/eslint-config` to your ESLint config via `extends`:
+The order in which you extend ESLint rules matters.
+The `@metamask/*` eslint configs should be added to the `extends` array _last_,
+with `@metamask/eslint-config` first, and `@metamask/eslint-config-*` in any
+order thereafter.
 
 ```js
 module.exports = {
   extends: [
+    // This should be added last unless you know what you're doing.
     '@metamask/eslint-config',
   ],
 }

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -27,10 +27,14 @@
   "homepage": "https://github.com/MetaMask/eslint-config#readme",
   "devDependencies": {
     "eslint": "^7.7.0",
-    "eslint-plugin-import": "^2.22.0"
+    "eslint-plugin-import": "^2.22.0",
+    "eslint-plugin-prettier": "^3.3.1",
+    "prettier": "^2.2.1"
   },
   "peerDependencies": {
     "eslint": "^7.7.0",
-    "eslint-plugin-import": "^2.22.0"
+    "eslint-plugin-import": "^2.22.0",
+    "eslint-plugin-prettier": "^3.3.1",
+    "prettier": "^2.2.1"
   }
 }

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -27,12 +27,14 @@
   "homepage": "https://github.com/MetaMask/eslint-config#readme",
   "devDependencies": {
     "eslint": "^7.7.0",
+    "eslint-config-prettier": "^8.1.0",
     "eslint-plugin-import": "^2.22.0",
     "eslint-plugin-prettier": "^3.3.1",
     "prettier": "^2.2.1"
   },
   "peerDependencies": {
     "eslint": "^7.7.0",
+    "eslint-config-prettier": "^8.1.0",
     "eslint-plugin-import": "^2.22.0",
     "eslint-plugin-prettier": "^3.3.1",
     "prettier": "^2.2.1"

--- a/packages/base/src/index.js
+++ b/packages/base/src/index.js
@@ -97,12 +97,8 @@ module.exports = {
 
     // Core rules
     'accessor-pairs': 'error',
-    'array-bracket-spacing': ['error', 'never'],
     'array-callback-return': 'error',
-    'arrow-parens': 'error',
     'block-scoped-var': 'error',
-    'block-spacing': ['error', 'always'],
-    'brace-style': 'error',
     'camelcase': [
       'error',
       {
@@ -110,31 +106,15 @@ module.exports = {
         allow: ['^UNSAFE_'],
       },
     ],
-    'comma-dangle': ['error', 'always-multiline'],
-    'comma-style': ['error', 'last'],
-    'computed-property-spacing': 'error',
     'consistent-return': 'error',
     'consistent-this': ['error', 'self'],
     'default-case': 'error',
     'default-param-last': 'error',
-    'dot-location': ['error', 'property'],
     'dot-notation': 'error',
-    'eol-last': 'error',
     'eqeqeq': ['error', 'allow-null'],
-    'func-call-spacing': 'error',
     'func-name-matching': 'error',
     'grouped-accessor-pairs': 'error',
     'guard-for-in': 'error',
-    'jsx-quotes': ['error', 'prefer-double'],
-    'key-spacing': 'error',
-    'keyword-spacing': [
-      'error',
-      {
-        before: true,
-        after: true,
-      },
-    ],
-    'linebreak-style': 'error',
     'lines-between-class-members': 'error',
     'max-statements-per-line': [
       'error',
@@ -149,7 +129,6 @@ module.exports = {
         capIsNew: false,
       },
     ],
-    'new-parens': 'error',
     'no-alert': 'error',
     'no-array-constructor': 'error',
     'no-bitwise': 'error',
@@ -165,8 +144,6 @@ module.exports = {
     'no-extend-native': 'error',
     'no-extra-bind': 'error',
     'no-extra-label': 'error',
-    'no-extra-parens': ['error', 'functions'],
-    'no-floating-decimal': 'error',
     'no-implicit-coercion': 'error',
     'no-implicit-globals': 'error',
     'no-implied-eval': 'error',
@@ -185,14 +162,7 @@ module.exports = {
     'no-lonely-if': 'error',
     'no-loop-func': 'error',
     'no-multi-assign': 'error',
-    'no-multi-spaces': 'error',
     'no-multi-str': 'error',
-    'no-multiple-empty-lines': [
-      'error',
-      {
-        max: 1,
-      },
-    ],
     'no-native-reassign': 'error',
     'no-negated-condition': 'error',
     'no-negated-in-lhs': 'error',
@@ -216,10 +186,8 @@ module.exports = {
     'no-script-url': 'error',
     'no-self-compare': 'error',
     'no-shadow': 'error',
-    'no-spaced-func': 'error',
     'no-template-curly-in-string': 'error',
     'no-throw-literal': 'error',
-    'no-trailing-spaces': 'error',
     'no-undef-init': 'error',
     'no-unmodified-loop-condition': 'error',
     'no-unneeded-ternary': [
@@ -257,16 +225,6 @@ module.exports = {
     'no-useless-return': 'error',
     'no-var': 'error',
     'no-void': 'error',
-    'no-whitespace-before-property': 'error',
-    'nonblock-statement-body-position': 'error',
-    'object-curly-newline': [
-      'error',
-      {
-        consistent: true,
-        multiline: true,
-      },
-    ],
-    'object-curly-spacing': ['error', 'always'],
     'object-shorthand': 'error',
     'one-var': [
       'error',
@@ -275,16 +233,6 @@ module.exports = {
       },
     ],
     'operator-assignment': 'error',
-    'operator-linebreak': [
-      'error',
-      'after',
-      {
-        overrides: {
-          '?': 'ignore',
-          ':': 'ignore',
-        },
-      },
-    ],
     'padding-line-between-statements': [
       'error',
       {
@@ -325,34 +273,6 @@ module.exports = {
     'radix': 'error',
     'require-atomic-updates': 'error',
     'require-unicode-regexp': 'error',
-    'rest-spread-spacing': 'error',
-    'semi': ['error', 'always'],
-    'semi-spacing': [
-      'error',
-      {
-        before: false,
-        after: true,
-      },
-    ],
-    'semi-style': 'error',
-    'space-before-blocks': ['error', 'always'],
-    'space-before-function-paren': [
-      'error',
-      {
-        anonymous: 'always',
-        asyncArrow: 'always',
-        named: 'never',
-      },
-    ],
-    'space-in-parens': ['error', 'never'],
-    'space-infix-ops': 'error',
-    'space-unary-ops': [
-      'error',
-      {
-        words: true,
-        nonwords: false,
-      },
-    ],
     'spaced-comment': [
       'error',
       'always',
@@ -369,13 +289,7 @@ module.exports = {
         exceptions: ['=', '-'],
       },
     ],
-    'switch-colon-spacing': 'error',
     'symbol-description': 'error',
-    'template-curly-spacing': ['error', 'never'],
-    'template-tag-spacing': 'error',
-    'unicode-bom': 'error',
-    'wrap-iife': ['error', 'any'],
-    'yield-star-spacing': ['error', 'both'],
     'yoda': ['error', 'never'],
 
     // import plugin rules

--- a/packages/base/src/index.js
+++ b/packages/base/src/index.js
@@ -9,8 +9,6 @@ module.exports = {
   extends: ['eslint:recommended', 'plugin:prettier/recommended'],
 
   rules: {
-    // Rules required for Prettier
-
     'prettier/prettier': [
       'error',
       {

--- a/packages/base/src/index.js
+++ b/packages/base/src/index.js
@@ -4,22 +4,102 @@ module.exports = {
     'shared-node-browser': true,
   },
 
-  plugins: ['import'],
+  plugins: ['import', 'prettier'],
 
-  extends: ['eslint:recommended'],
+  extends: ['eslint:recommended', 'plugin:prettier/recommended'],
 
   rules: {
+    // Rules required for Prettier
+
+    'prettier/prettier': [
+      'error',
+      {
+        singleQuote: true,
+        trailingComma: 'all',
+        quoteProps: 'consistent',
+      },
+      {
+        // Allow consumers to override this prettier config.
+        usePrettierrc: true,
+      },
+    ],
+
+    // In order to match the prettier spec, you have to enable lines around
+    // comments before and after blocks, objects, and arrays.
+    // https://github.com/prettier/eslint-config-prettier#lines-around-comment
+    'lines-around-comment': [
+      'error',
+      {
+        beforeBlockComment: true,
+        afterLineComment: false,
+        allowBlockStart: true,
+        allowBlockEnd: true,
+        allowObjectStart: true,
+        allowObjectEnd: true,
+        allowArrayStart: true,
+        allowArrayEnd: true,
+      },
+    ],
+
+    // Prettier has some opinions on mixed-operators, and there is ongoing work
+    // to make the output code clear. It is better today then it was when the first
+    // PR to add prettier. That being said, the workaround for keeping this rule enabled
+    // requires breaking parts of operations into different variables -- which I believe
+    // to be worse. https://github.com/prettier/eslint-config-prettier#no-mixed-operators
+    'no-mixed-operators': 'off',
+
+    // Prettier wraps single line functions with ternaries, etc in parens by default, but
+    // if the line is long enough it breaks it into a separate line and removes the parens.
+    // The second behavior conflicts with this rule. There is some guides on the repo about
+    // how you can keep it enabled:
+    // https://github.com/prettier/eslint-config-prettier#no-confusing-arrow
+    // However, in practice this conflicts with prettier adding parens around short lines,
+    // when autofixing in vscode and others.
+    'no-confusing-arrow': 'off',
+
+    // There is no configuration in prettier for how it stylizes regexes, which conflicts
+    // with wrap-regex.
+    'wrap-regex': 'off',
+
+    // Prettier handles all indentation automagically. it can be configured here
+    // https://prettier.io/docs/en/options.html#tab-width but the default matches our
+    // style.
+    'indent': 'off',
+
+    // This rule conflicts with the way that prettier breaks code across multiple lines when
+    // it exceeds the maximum length. Prettier optimizes for readability while simultaneously
+    // maximizing the amount of code per line.
+    'function-paren-newline': 'off',
+
+    // This rule throws an error when there is a line break in an arrow function declaration
+    // but prettier breaks arrow function declarations to be as readable as possible while
+    // still conforming to the width rules.
+    'implicit-arrow-linebreak': 'off',
+
+    // This rule would result in an increase in white space in lines with generator functions,
+    // which impacts prettier's goal of maximizing code per line and readability. There is no
+    // current workaround.
+    'generator-star-spacing': 'off',
+
+    'arrow-body-style': 'off',
+    'arrow-spacing': 'off',
+    'comma-spacing': 'off',
+    'curly': ['error', 'all'],
+    'max-len': 'off',
+    'no-tabs': 'error',
+    'no-unexpected-multiline': 'off',
+    'prefer-arrow-callback': 'off',
+    'quotes': 'off',
+
+    // Not required by prettier, but potentially gotchas
+    'no-restricted-syntax': ['error', 'SequenceExpression'],
+    'no-sequences': 'off',
+
+    // Core rules
     'accessor-pairs': 'error',
     'array-bracket-spacing': ['error', 'never'],
     'array-callback-return': 'error',
     'arrow-parens': 'error',
-    'arrow-spacing': [
-      'error',
-      {
-        before: true,
-        after: true,
-      },
-    ],
     'block-scoped-var': 'error',
     'block-spacing': ['error', 'always'],
     'brace-style': 'error',
@@ -31,18 +111,10 @@ module.exports = {
       },
     ],
     'comma-dangle': ['error', 'always-multiline'],
-    'comma-spacing': [
-      'error',
-      {
-        before: false,
-        after: true,
-      },
-    ],
     'comma-style': ['error', 'last'],
     'computed-property-spacing': 'error',
     'consistent-return': 'error',
     'consistent-this': ['error', 'self'],
-    'curly': 'error',
     'default-case': 'error',
     'default-param-last': 'error',
     'dot-location': ['error', 'property'],
@@ -51,24 +123,8 @@ module.exports = {
     'eqeqeq': ['error', 'allow-null'],
     'func-call-spacing': 'error',
     'func-name-matching': 'error',
-    'function-paren-newline': ['error', 'consistent'],
-    'generator-star-spacing': [
-      'error',
-      {
-        before: true,
-        after: true,
-      },
-    ],
     'grouped-accessor-pairs': 'error',
     'guard-for-in': 'error',
-    'implicit-arrow-linebreak': 'error',
-    'indent': [
-      'error',
-      2,
-      {
-        SwitchCase: 1,
-      },
-    ],
     'jsx-quotes': ['error', 'prefer-double'],
     'key-spacing': 'error',
     'keyword-spacing': [
@@ -79,7 +135,6 @@ module.exports = {
       },
     ],
     'linebreak-style': 'error',
-    'lines-around-comment': 'error',
     'lines-between-class-members': 'error',
     'max-statements-per-line': [
       'error',
@@ -100,7 +155,6 @@ module.exports = {
     'no-bitwise': 'error',
     'no-buffer-constructor': 'error',
     'no-caller': 'error',
-    'no-confusing-arrow': 'error',
     'no-constructor-return': 'error',
     'no-div-regex': 'error',
     'no-duplicate-imports': 'error',
@@ -130,7 +184,6 @@ module.exports = {
     'no-lone-blocks': 'error',
     'no-lonely-if': 'error',
     'no-loop-func': 'error',
-    'no-mixed-operators': 'error',
     'no-multi-assign': 'error',
     'no-multi-spaces': 'error',
     'no-multi-str': 'error',
@@ -162,10 +215,8 @@ module.exports = {
     'no-return-await': 'off', // See https://gist.github.com/Gudahtt/618b89f40164af323e08bbdbd17a1769#gistcomment-3182478
     'no-script-url': 'error',
     'no-self-compare': 'error',
-    'no-sequences': 'error',
     'no-shadow': 'error',
     'no-spaced-func': 'error',
-    'no-tabs': 'error',
     'no-template-curly-in-string': 'error',
     'no-throw-literal': 'error',
     'no-trailing-spaces': 'error',
@@ -271,14 +322,6 @@ module.exports = {
     'prefer-rest-params': 'error',
     'prefer-spread': 'error',
     'prefer-template': 'error',
-    'quotes': [
-      'error',
-      'single',
-      {
-        avoidEscape: true,
-        allowTemplateLiterals: true,
-      },
-    ],
     'radix': 'error',
     'require-atomic-updates': 'error',
     'require-unicode-regexp': 'error',
@@ -332,13 +375,13 @@ module.exports = {
     'template-tag-spacing': 'error',
     'unicode-bom': 'error',
     'wrap-iife': ['error', 'any'],
-    'wrap-regex': 'error',
     'yield-star-spacing': ['error', 'both'],
     'yoda': ['error', 'never'],
 
     // import plugin rules
     'import/default': 'error',
     'import/export': 'error',
+    'import/exports-last': 'off',
     'import/extensions': [
       'error',
       'never',
@@ -368,6 +411,7 @@ module.exports = {
         commonjs: true,
       },
     ],
+    'import/no-unused-modules': 'off',
     'import/no-useless-path-segments': [
       'error',
       {

--- a/packages/base/src/index.js
+++ b/packages/base/src/index.js
@@ -9,6 +9,7 @@ module.exports = {
   extends: ['eslint:recommended', 'plugin:prettier/recommended'],
 
   rules: {
+    /* Prettier rules */
     'prettier/prettier': [
       'error',
       {
@@ -23,15 +24,15 @@ module.exports = {
     ],
 
     // Prettier has some opinions on mixed-operators, and there is ongoing work
-    // to make the output code clear. It is better today then it was when the first
-    // PR to add prettier. That being said, the workaround for keeping this rule enabled
-    // requires breaking parts of operations into different variables -- which I believe
-    // to be worse. https://github.com/prettier/eslint-config-prettier#no-mixed-operators
+    // to make the output code clear. The workaround for keeping this rule enabled
+    // requires breaking parts of operations into different variables -- which we
+    // decided to be worse.
+    // https://github.com/prettier/eslint-config-prettier#no-mixed-operators
     'no-mixed-operators': 'off',
 
-    // Prettier wraps single line functions with ternaries, etc in parens by default, but
+    // Prettier wraps e.g. single line functions with ternaries in parens by default, but
     // if the line is long enough it breaks it into a separate line and removes the parens.
-    // The second behavior conflicts with this rule. There is some guides on the repo about
+    // The second behavior conflicts with this rule. There is some advice on the repo about
     // how you can keep it enabled:
     // https://github.com/prettier/eslint-config-prettier#no-confusing-arrow
     // However, in practice this conflicts with prettier adding parens around short lines,
@@ -42,9 +43,9 @@ module.exports = {
     // with wrap-regex.
     'wrap-regex': 'off',
 
-    // Prettier handles all indentation automagically. it can be configured here
-    // https://prettier.io/docs/en/options.html#tab-width but the default matches our
-    // style.
+    // Prettier handles all indentation automagically. It defaults to 2 spaces,
+    // which is what we want.
+    // https://prettier.io/docs/en/options.html#tab-width
     'indent': 'off',
 
     // This rule conflicts with the way that prettier breaks code across multiple lines when
@@ -72,11 +73,11 @@ module.exports = {
     'prefer-arrow-callback': 'off',
     'quotes': 'off',
 
-    // Not required by prettier, but potentially gotchas
+    // Not required by prettier, but potentially gotchas.
     'no-restricted-syntax': ['error', 'SequenceExpression'],
     'no-sequences': 'off',
 
-    // Core rules
+    /* Core rules */
     'accessor-pairs': 'error',
     'array-callback-return': 'error',
     'block-scoped-var': 'error',
@@ -273,7 +274,7 @@ module.exports = {
     'symbol-description': 'error',
     'yoda': ['error', 'never'],
 
-    // import plugin rules
+    /* import plugin rules */
     'import/default': 'error',
     'import/export': 'error',
     'import/exports-last': 'off',

--- a/packages/base/src/index.js
+++ b/packages/base/src/index.js
@@ -22,23 +22,6 @@ module.exports = {
       },
     ],
 
-    // In order to match the prettier spec, you have to enable lines around
-    // comments before and after blocks, objects, and arrays.
-    // https://github.com/prettier/eslint-config-prettier#lines-around-comment
-    'lines-around-comment': [
-      'error',
-      {
-        beforeBlockComment: true,
-        afterLineComment: false,
-        allowBlockStart: true,
-        allowBlockEnd: true,
-        allowObjectStart: true,
-        allowObjectEnd: true,
-        allowArrayStart: true,
-        allowArrayEnd: true,
-      },
-    ],
-
     // Prettier has some opinions on mixed-operators, and there is ongoing work
     // to make the output code clear. It is better today then it was when the first
     // PR to add prettier. That being said, the workaround for keeping this rule enabled

--- a/packages/jest/README.md
+++ b/packages/jest/README.md
@@ -13,11 +13,17 @@ yarn add --dev \
     @metamask/eslint-config-jest@^5.0.0
 ```
 
+The order in which you extend ESLint rules matters.
+The `@metamask/*` eslint configs should be added to the `extends` array _last_,
+with `@metamask/eslint-config` first, and `@metamask/eslint-config-*` in any
+order thereafter.
+
 ```js
 module.exports = {
   root: true,
 
   extends: [
+    // These should be added last unless you know what you're doing.
     '@metamask/eslint-config',
     '@metamask/eslint-config-jest',
   ],

--- a/packages/jest/src/index.js
+++ b/packages/jest/src/index.js
@@ -1,20 +1,15 @@
 module.exports = {
-  plugins: [
-    'jest',
-  ],
+  plugins: ['jest'],
 
   env: {
     'jest/globals': true,
   },
 
-  extends: [
-    'plugin:jest/recommended',
-    'plugin:jest/style',
-  ],
+  extends: ['plugin:jest/recommended', 'plugin:jest/style'],
 
   rules: {
-    'jest/consistent-test-it': ['error', { 'fn': 'it' }],
-    'jest/lowercase-name': ['error', { 'ignore': ['describe'] }],
+    'jest/consistent-test-it': ['error', { fn: 'it' }],
+    'jest/lowercase-name': ['error', { ignore: ['describe'] }],
     'jest/no-duplicate-hooks': 'error',
     'jest/no-hooks': 'off',
     'jest/no-if': 'error',
@@ -28,15 +23,16 @@ module.exports = {
     'jest/prefer-todo': 'error',
     'jest/require-top-level-describe': 'error',
     'jest/require-to-throw-message': 'error',
-    'jest/valid-expect': ['error', { 'alwaysAwait': true }],
+    'jest/valid-expect': ['error', { alwaysAwait: true }],
     'jest/no-restricted-matchers': [
       'error',
       {
-        'resolves': 'Use `expect(await promise)` instead.',
-        'toBeFalsy': 'Avoid `toBeFalsy`',
-        'toBeTruthy': 'Avoid `toBeTruthy`',
-        'toMatchSnapshot': 'Use `toMatchInlineSnapshot()` instead',
-        'toThrowErrorMatchingSnapshot': 'Use `toThrowErrorMatchingInlineSnapshot()` instead',
+        resolves: 'Use `expect(await promise)` instead.',
+        toBeFalsy: 'Avoid `toBeFalsy`',
+        toBeTruthy: 'Avoid `toBeTruthy`',
+        toMatchSnapshot: 'Use `toMatchInlineSnapshot()` instead',
+        toThrowErrorMatchingSnapshot:
+          'Use `toThrowErrorMatchingInlineSnapshot()` instead',
       },
     ],
   },

--- a/packages/mocha/README.md
+++ b/packages/mocha/README.md
@@ -13,11 +13,17 @@ yarn add --dev \
     @metamask/eslint-config-mocha@^5.0.0
 ```
 
+The order in which you extend ESLint rules matters.
+The `@metamask/*` eslint configs should be added to the `extends` array _last_,
+with `@metamask/eslint-config` first, and `@metamask/eslint-config-*` in any
+order thereafter.
+
 ```js
 module.exports = {
   root: true,
 
   extends: [
+    // These should be added last unless you know what you're doing.
     '@metamask/eslint-config',
     '@metamask/eslint-config-mocha',
   ],

--- a/packages/mocha/src/index.js
+++ b/packages/mocha/src/index.js
@@ -1,12 +1,10 @@
 const simpleTestNameRegex = '^[#_]{0,2}[A-Za-z0-9]';
 
 module.exports = {
-  plugins: [
-    'mocha',
-  ],
+  plugins: ['mocha'],
 
   env: {
-    'mocha': true,
+    mocha: true,
   },
 
   rules: {

--- a/packages/nodejs/README.md
+++ b/packages/nodejs/README.md
@@ -13,9 +13,15 @@ yarn add --dev \
     @metamask/eslint-config-nodejs@^5.0.0
 ```
 
+The order in which you extend ESLint rules matters.
+The `@metamask/*` eslint configs should be added to the `extends` array _last_,
+with `@metamask/eslint-config` first, and `@metamask/eslint-config-*` in any
+order thereafter.
+
 ```js
 module.exports = {
   extends: [
+    // These should be added last unless you know what you're doing.
     '@metamask/eslint-config',
     '@metamask/eslint-config-nodejs',
   ],

--- a/packages/nodejs/src/index.js
+++ b/packages/nodejs/src/index.js
@@ -1,7 +1,5 @@
 module.exports = {
-  plugins: [
-    'node',
-  ],
+  plugins: ['node'],
 
   env: {
     node: true,

--- a/packages/typescript/README.md
+++ b/packages/typescript/README.md
@@ -14,17 +14,23 @@ yarn add --dev \
     @metamask/eslint-config-typescript@^5.0.0
 ```
 
+The order in which you extend ESLint rules matters.
+The `@metamask/*` eslint configs should be added to the `extends` array _last_,
+with `@metamask/eslint-config` first, and `@metamask/eslint-config-*` in any
+order thereafter.
+
 ```js
 module.exports = {
   root: true,
 
   extends: [
+    // This should be added last unless you know what you're doing.
     '@metamask/eslint-config',
   ],
 
   overrides: [
     // The TypeScript config disables certain rules that you want to keep for
-    // .js files, so it should be added in an override.
+    // non-TypeScript files, so it should be added in an override.
     {
       files: ['*.ts'],
       extends: [

--- a/packages/typescript/src/index.js
+++ b/packages/typescript/src/index.js
@@ -2,12 +2,10 @@ module.exports = {
   parser: '@typescript-eslint/parser',
 
   parserOptions: {
-    'sourceType': 'module',
+    sourceType: 'module',
   },
 
-  plugins: [
-    '@typescript-eslint',
-  ],
+  plugins: ['@typescript-eslint'],
 
   rules: {
     // Checked by TypeScript - ts(2378)
@@ -44,16 +42,19 @@ module.exports = {
     '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/explicit-member-accessibility': 'off',
     '@typescript-eslint/explicit-module-boundary-types': 'off',
-    '@typescript-eslint/member-delimiter-style': ['error', {
-      'multiline': {
-        'delimiter': 'semi',
-        'requireLast': true,
+    '@typescript-eslint/member-delimiter-style': [
+      'error',
+      {
+        multiline: {
+          delimiter: 'semi',
+          requireLast: true,
+        },
+        singleline: {
+          delimiter: 'semi',
+          requireLast: false,
+        },
       },
-      'singleline': {
-        'delimiter': 'semi',
-        'requireLast': false,
-      },
-    }],
+    ],
     '@typescript-eslint/member-ordering': 'off',
     '@typescript-eslint/naming-convention': 'off', // Requires type information
     '@typescript-eslint/no-dynamic-delete': 'off',
@@ -67,7 +68,10 @@ module.exports = {
     '@typescript-eslint/no-inferrable-types': 'error',
     '@typescript-eslint/no-misused-new': 'error',
     '@typescript-eslint/no-misused-promises': 'off', // Requires type information
-    '@typescript-eslint/no-namespace': ['error', { 'allowDefinitionFiles': true }],
+    '@typescript-eslint/no-namespace': [
+      'error',
+      { allowDefinitionFiles: true },
+    ],
     '@typescript-eslint/no-non-null-asserted-optional-chain': 'error',
     '@typescript-eslint/no-non-null-assertion': 'error',
     '@typescript-eslint/no-parameter-properties': 'error',
@@ -117,7 +121,7 @@ module.exports = {
     '@typescript-eslint/func-call-spacing': 'error',
     'func-call-spacing': 'off',
 
-    '@typescript-eslint/indent': ['error', 2, { 'SwitchCase': 1 }],
+    '@typescript-eslint/indent': ['error', 2, { SwitchCase: 1 }],
     'indent': 'off',
 
     '@typescript-eslint/no-array-constructor': 'error',
@@ -138,19 +142,29 @@ module.exports = {
     '@typescript-eslint/no-magic-numbers': 'off',
     'no-magic-numbers': 'off',
 
-    '@typescript-eslint/no-unused-expressions': ['error', { 'allowShortCircuit': true, 'allowTernary': true }],
+    '@typescript-eslint/no-unused-expressions': [
+      'error',
+      { allowShortCircuit: true, allowTernary: true },
+    ],
     'no-unused-expressions': 'off',
 
-    '@typescript-eslint/no-unused-vars': ['error', { 'vars': 'all', 'args': 'all', 'argsIgnorePattern': '[_]+' }],
+    '@typescript-eslint/no-unused-vars': [
+      'error',
+      { vars: 'all', args: 'all', argsIgnorePattern: '[_]+' },
+    ],
     'no-unused-vars': 'off',
 
-    '@typescript-eslint/no-use-before-define': ['error', { 'functions': false }],
+    '@typescript-eslint/no-use-before-define': ['error', { functions: false }],
     'no-use-before-define': 'off',
 
     '@typescript-eslint/no-useless-constructor': 'error',
     'no-useless-constructor': 'off',
 
-    '@typescript-eslint/quotes': ['error', 'single', { 'avoidEscape': true, 'allowTemplateLiterals': true }],
+    '@typescript-eslint/quotes': [
+      'error',
+      'single',
+      { avoidEscape: true, allowTemplateLiterals: true },
+    ],
     'quotes': 'off',
 
     '@typescript-eslint/require-await': 'off', // Requires type information
@@ -163,9 +177,9 @@ module.exports = {
     '@typescript-eslint/space-before-function-paren': [
       'error',
       {
-        'anonymous': 'always',
-        'named': 'never',
-        'asyncArrow': 'always',
+        anonymous: 'always',
+        named: 'never',
+        asyncArrow: 'always',
       },
     ],
     'space-before-function-paren': 'off',

--- a/packages/typescript/src/index.js
+++ b/packages/typescript/src/index.js
@@ -42,19 +42,6 @@ module.exports = {
     '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/explicit-member-accessibility': 'off',
     '@typescript-eslint/explicit-module-boundary-types': 'off',
-    '@typescript-eslint/member-delimiter-style': [
-      'error',
-      {
-        multiline: {
-          delimiter: 'semi',
-          requireLast: true,
-        },
-        singleline: {
-          delimiter: 'semi',
-          requireLast: false,
-        },
-      },
-    ],
     '@typescript-eslint/member-ordering': 'off',
     '@typescript-eslint/naming-convention': 'off', // Requires type information
     '@typescript-eslint/no-dynamic-delete': 'off',
@@ -103,26 +90,13 @@ module.exports = {
     '@typescript-eslint/strict-boolean-expressions': 'off', // Requires type information
     '@typescript-eslint/switch-exhaustiveness-check': 'off', // Requires type information
     '@typescript-eslint/triple-slash-reference': 'error',
-    '@typescript-eslint/type-annotation-spacing': 'error',
     '@typescript-eslint/typedef': 'off',
     '@typescript-eslint/unbound-method': 'off', // Requires type information
     '@typescript-eslint/unified-signatures': 'error',
 
     // "Extension Rules" from @typescript-eslint/eslint-plugin
-    '@typescript-eslint/brace-style': 'error',
-    'brace-style': 'off',
-
-    '@typescript-eslint/comma-spacing': 'error',
-    'comma-spacing': 'off',
-
     '@typescript-eslint/default-param-last': 'error',
     'default-param-last': 'off',
-
-    '@typescript-eslint/func-call-spacing': 'error',
-    'func-call-spacing': 'off',
-
-    '@typescript-eslint/indent': ['error', 2, { SwitchCase: 1 }],
-    'indent': 'off',
 
     '@typescript-eslint/no-array-constructor': 'error',
     'no-array-constructor': 'off',
@@ -135,9 +109,6 @@ module.exports = {
 
     '@typescript-eslint/no-extra-parens': 'off',
     'no-extra-parens': 'off',
-
-    '@typescript-eslint/no-extra-semi': 'error',
-    'no-extra-semi': 'off',
 
     '@typescript-eslint/no-magic-numbers': 'off',
     'no-magic-numbers': 'off',
@@ -170,18 +141,5 @@ module.exports = {
     '@typescript-eslint/require-await': 'off', // Requires type information
 
     '@typescript-eslint/return-await': 'off', // Requires type information
-
-    '@typescript-eslint/semi': ['error', 'always'],
-    'semi': 'off',
-
-    '@typescript-eslint/space-before-function-paren': [
-      'error',
-      {
-        anonymous: 'always',
-        named: 'never',
-        asyncArrow: 'always',
-      },
-    ],
-    'space-before-function-paren': 'off',
   },
 };

--- a/scripts/validate-prettier-rules.js
+++ b/scripts/validate-prettier-rules.js
@@ -1,0 +1,57 @@
+const fs = require('fs');
+const pathUtils = require('path');
+const prettierConfig = require('eslint-config-prettier');
+
+const OFF = 'off';
+
+// The prettier rules that should never be included in a config.
+const disabledPrettierRules = Object.entries(prettierConfig.rules).reduce(
+  (allRules, [ruleName, ruleValue]) => {
+    // Rules set to 'off' should never be enabled.
+    // Rules set to 0 (number) may sometimes be included. We don't attend to those.
+    if (ruleValue === OFF) {
+      allRules.push(ruleName);
+    }
+    return allRules;
+  },
+  [],
+);
+
+// The path to the monorepo packages directory
+const PACKAGES_DIR_PATH = pathUtils.join(__dirname, '../packages');
+
+// Get the configs from all packages, keyed by package names
+const eslintConfigs = fs
+  .readdirSync(PACKAGES_DIR_PATH)
+  .reduce((allConfigs, dirName) => {
+    const packagePath = pathUtils.join(PACKAGES_DIR_PATH, dirName);
+    const manifestPath = pathUtils.join(packagePath, 'package.json');
+    const { name: packageName } = JSON.parse(
+      fs.readFileSync(manifestPath, 'utf-8'),
+    );
+
+    allConfigs[packageName] = require(packagePath);
+    return allConfigs;
+  }, {});
+
+// Iterate over our configs, identify rules that are enabled even though they shouldn't be,
+// and throw an error if any are found.
+// TODO: Collect violations for all packages.
+Object.entries(eslintConfigs).forEach(
+  ([packageName, { rules: currentRuleSet }]) => {
+    const violations = [];
+    disabledPrettierRules.forEach((ruleName) => {
+      if (ruleName in currentRuleSet && currentRuleSet[ruleName] !== OFF) {
+        violations.push(ruleName);
+      }
+    });
+
+    if (violations.length > 0) {
+      throw new Error(
+        `${packageName} has enabled the following rules that are disabled by prettier:\n${violations.join(
+          '\n',
+        )}`,
+      );
+    }
+  },
+);

--- a/scripts/validate-prettier-rules.js
+++ b/scripts/validate-prettier-rules.js
@@ -36,7 +36,6 @@ const eslintConfigs = fs
 
 // Iterate over our configs, identify rules that are enabled even though they shouldn't be,
 // and throw an error if any are found.
-// TODO: Collect violations for all packages.
 Object.entries(eslintConfigs).forEach(
   ([packageName, { rules: currentRuleSet }]) => {
     const violations = [];

--- a/yarn.lock
+++ b/yarn.lock
@@ -2005,6 +2005,13 @@ eslint-plugin-node@^11.1.0:
     resolve "^1.10.1"
     semver "^6.1.0"
 
+eslint-plugin-prettier@^3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.3.1.tgz#7079cfa2497078905011e6f82e8dd8453d1371b7"
+  integrity sha512-Rq3jkcFY8RYeQLgk2cCwuc0P7SEFwDravPhsJZOQ5N4YI4DSg50NyqJ/9gdZHzQlHf8MvafSesbNJCcP/FF6pQ==
+  dependencies:
+    prettier-linter-helpers "^1.0.0"
+
 eslint-scope@^5.0.0, eslint-scope@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"
@@ -2164,6 +2171,11 @@ fast-deep-equal@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz#545145077c501491e33b15ec408c294376e94ae4"
   integrity sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==
+
+fast-diff@^1.1.2:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.2.0.tgz#73ee11982d86caaf7959828d519cfe927fac5f03"
+  integrity sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==
 
 fast-glob@^3.1.1:
   version "3.2.4"
@@ -4058,6 +4070,18 @@ prelude-ls@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
+
+prettier-linter-helpers@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz#d23d41fe1375646de2d0104d3454a3008802cf7b"
+  integrity sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==
+  dependencies:
+    fast-diff "^1.1.2"
+
+prettier@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.2.1.tgz#795a1a78dd52f073da0cd42b21f9c91381923ff5"
+  integrity sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==
 
 process-nextick-args@~2.0.0:
   version "2.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1935,6 +1935,11 @@ escape-string-regexp@^1.0.5:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
 
+eslint-config-prettier@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-8.1.0.tgz#4ef1eaf97afe5176e6a75ddfb57c335121abc5a6"
+  integrity sha512-oKMhGv3ihGbCIimCAjqkdzx2Q+jthoqnXSP+d86M9tptwugycmTFdVR4IpLgq2c4SHifbwO90z2fQ8/Aio73yw==
+
 eslint-import-resolver-node@^0.3.4:
   version "0.3.4"
   resolved "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.4.tgz#85ffa81942c25012d8231096ddf679c03042c717"


### PR DESCRIPTION
This PR adds `prettier` to the base config, and updates its rules for `prettier` compatibility. It accomplishes this by copying [some relevant edge case rules from the extension](https://github.com/MetaMask/metamask-extension/blob/5a233e4/.eslintrc.js#L57-L106), extending the rules from `eslint-config-prettier`, and _disabling all rules overriding those `prettier` rules.

I tested it with the extension and it resulted in fairly minimal changes, mostly related to `quoteProps`.