### PR TITLE
5.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - **(SEMVER-MAJOR)** Enable `semi` in base config ([#101](https://github.com/MetaMask/eslint-config/pull/101))
 - **(SEMVER-MAJOR)** Disallow spaces before parentheses of named functions ([#101](https://github.com/MetaMask/eslint-config/pull/101))
+- **(SEMVER-MAJOR)** Upgrade to TypeScript v4 and corresponding `@typescript-eslint` dependencies ([#79](https://github.com/MetaMask/eslint-config/pull/79), [#80](https://github.com/MetaMask/eslint-config/pull/80), [#103](https://github.com/MetaMask/eslint-config/pull/103))
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [5.0.0] - 2021-02-02
+
+### Changed
+
+- **(SEMVER-MAJOR)** Enable `semi` in base config ([#101](https://github.com/MetaMask/eslint-config/pull/101))
+  - This may just be fixable with `eslint . --fix`, but we consider it breaking because it's a major stylistic change.
+- Disallow spaces before parentheses of named functions ([#101](https://github.com/MetaMask/eslint-config/pull/101))
+
 ## [4.1.0] - 2020-10-21
 
 ### Changed
@@ -17,7 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 
-- **Breaking**: Update to ESLint v7 (#46, #58, #62, #63)
+- **(SEMVER-MAJOR)** Update to ESLint v7 (#46, #58, #62, #63)
 - Relax `member-delimiter-style` for TypeScript ([#68](https://github.com/MetaMask/eslint-config/pull/68))
 - Disable `space-before-function-paren` for TypeScript ([#65](https://github.com/MetaMask/eslint-config/pull/65))
 
@@ -93,7 +101,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Add base, TypeScript, and Jest configs (#3)
 
-[Unreleased]:https://github.com/MetaMask/eslint-config/compare/v4.1.0...HEAD
+[Unreleased]:https://github.com/MetaMask/eslint-config/compare/v5.0.0...HEAD
+[5.0.0]:https://github.com/MetaMask/eslint-config/compare/v4.1.0...v5.0.0
 [4.1.0]:https://github.com/MetaMask/eslint-config/compare/v4.0.0...v4.1.0
 [4.0.0]:https://github.com/MetaMask/eslint-config/compare/v3.2.0...v4.0.0
 [3.2.0]:https://github.com/MetaMask/eslint-config/compare/v3.1.0...v3.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 
 - **(SEMVER-MAJOR)** Enable `semi` in base config ([#101](https://github.com/MetaMask/eslint-config/pull/101))
-  - This may just be fixable with `eslint . --fix`, but we consider it breaking because it's a major stylistic change.
-- Disallow spaces before parentheses of named functions ([#101](https://github.com/MetaMask/eslint-config/pull/101))
+- **(SEMVER-MAJOR)** Disallow spaces before parentheses of named functions ([#101](https://github.com/MetaMask/eslint-config/pull/101))
 
 ## [4.1.0] - 2020-10-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 
-- **(SEMVER-MAJOR)** Enable `semi` in base config ([#101](https://github.com/MetaMask/eslint-config/pull/101))
-- **(SEMVER-MAJOR)** Disallow spaces before parentheses of named functions ([#101](https://github.com/MetaMask/eslint-config/pull/101))
-- **(SEMVER-MAJOR)** Upgrade to TypeScript v4 and corresponding `@typescript-eslint` dependencies ([#79](https://github.com/MetaMask/eslint-config/pull/79), [#80](https://github.com/MetaMask/eslint-config/pull/80), [#103](https://github.com/MetaMask/eslint-config/pull/103))
+- **BREAKING:** Enable `semi` in base config ([#101](https://github.com/MetaMask/eslint-config/pull/101))
+- **BREAKING:** Disallow spaces before parentheses of named functions ([#101](https://github.com/MetaMask/eslint-config/pull/101))
+- **BREAKING:** Upgrade to TypeScript v4 and corresponding `@typescript-eslint` dependencies ([#79](https://github.com/MetaMask/eslint-config/pull/79), [#80](https://github.com/MetaMask/eslint-config/pull/80), [#103](https://github.com/MetaMask/eslint-config/pull/103))
 
 ## [4.1.0] - 2020-10-21
 
@@ -25,7 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 
-- **(SEMVER-MAJOR)** Update to ESLint v7 (#46, #58, #62, #63)
+- **BREAKING:** Update to ESLint v7 (#46, #58, #62, #63)
 - Relax `member-delimiter-style` for TypeScript ([#68](https://github.com/MetaMask/eslint-config/pull/68))
 - Disable `space-before-function-paren` for TypeScript ([#65](https://github.com/MetaMask/eslint-config/pull/65))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - **(SEMVER-MAJOR)** Disallow spaces before parentheses of named functions ([#101](https://github.com/MetaMask/eslint-config/pull/101))
 - **(SEMVER-MAJOR)** Upgrade to TypeScript v4 and corresponding `@typescript-eslint` dependencies ([#79](https://github.com/MetaMask/eslint-config/pull/79), [#80](https://github.com/MetaMask/eslint-config/pull/80), [#103](https://github.com/MetaMask/eslint-config/pull/103))
 
-### Fixed
-
-- Update `jest` config to account for breaking changes in `eslint-plugin-jest@^24.0.0` ([#90](https://github.com/MetaMask/eslint-config/pull/90))
-
 ## [4.1.0] - 2020-10-21
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - **(SEMVER-MAJOR)** Enable `semi` in base config ([#101](https://github.com/MetaMask/eslint-config/pull/101))
 - **(SEMVER-MAJOR)** Disallow spaces before parentheses of named functions ([#101](https://github.com/MetaMask/eslint-config/pull/101))
 
+### Fixed
+
+- Update `jest` config to account for breaking changes in `eslint-plugin-jest@^24.0.0` ([#90](https://github.com/MetaMask/eslint-config/pull/90))
+
 ## [4.1.0] - 2020-10-21
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/eslint-config",
-  "version": "4.1.0",
+  "version": "5.0.0",
   "description": "Shareable MetaMask ESLint config",
   "main": "config/index.js",
   "publishConfig": {


### PR DESCRIPTION
- Major version bump
  - Enabling the `semi` rule is a major change, if not necessarily breaking.
- Update changelog