### PR TITLE
WIP: Standardize dependabot settings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    target-branch: "main"
     allow:
-      - dependency-type: "development"
+      - dependency-name: "@metamask/*"
+        dependency-type: "development"
     versioning-strategy: "increase-if-necessary"


### PR DESCRIPTION
A few notes:

- `label`'s default value is `dependencies`, so I left that off
- `rebase-strategy`'s default value is `auto`, so I left that off
- It's possible that the `allow` setting could interfere with receiving security updates, so someone with security permissions may need to manually make that update within GitHub (https://docs.github.com/en/code-security/supply-chain-security/configuring-dependabot-security-updates) 
- I wanted to set the `schedule.timezone` for very early morning, to cut down on in-day noise, but I believe that may also effect getting security updates.

Also note that this config should be pretty portable -- one issue we'll need to rectify is the main branch name on different repositories differs.