### PR TITLE
Specify ecmaVersion for base and TypeScript configs

### DIFF
--- a/packages/base/src/index.js
+++ b/packages/base/src/index.js
@@ -4,6 +4,13 @@ module.exports = {
     'shared-node-browser': true,
   },
 
+  parserOptions: {
+    // As of 2021-03-31, ES2017 is our effective minimum version due to the use
+    // of Esprima by transitive dependencies.
+    // It doesn't handle object rest spread, which is a 2018 feature.
+    ecmaVersion: 2017,
+  },
+
   plugins: ['import', 'prettier'],
 
   extends: ['eslint:recommended', 'plugin:prettier/recommended'],

--- a/packages/typescript/src/index.js
+++ b/packages/typescript/src/index.js
@@ -2,6 +2,9 @@ module.exports = {
   parser: '@typescript-eslint/parser',
 
   parserOptions: {
+    // Should always to the latest release (not pre-release) here:
+    // https://github.com/tc39/ecma262/releases
+    ecmaVersion: 2020,
     sourceType: 'module',
   },
 


### PR DESCRIPTION
Specifies ES2017 and ES2020 as the `ecmaVersion` for the base and TypeScript configs, respectively.