### PR TITLE
Fix EcmaScript version config

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,10 +1,6 @@
 module.exports = {
   root: true,
 
-  parserOptions: {
-    ecmaVersion: 2017,
-  },
-
   extends: ['@metamask/eslint-config', '@metamask/eslint-config-nodejs'],
 
   overrides: [

--- a/packages/base/src/index.js
+++ b/packages/base/src/index.js
@@ -1,14 +1,12 @@
 module.exports = {
   env: {
-    'es6': true,
-    'shared-node-browser': true,
-  },
-
-  parserOptions: {
-    // As of 2021-03-31, ES2017 is our effective minimum version due to the use
+    // Specifying the ES version automatically sets the correct parser option.
+    // https://eslint.org/docs/user-guide/configuring/language-options#specifying-environments
+    // For JavaScript, ES2017 is our effective minimum version due to the use
     // of Esprima by transitive dependencies.
     // It doesn't handle object rest spread, which is a 2018 feature.
-    ecmaVersion: 2017,
+    'es2017': true,
+    'shared-node-browser': true,
   },
 
   plugins: ['import', 'prettier'],

--- a/packages/typescript/src/index.js
+++ b/packages/typescript/src/index.js
@@ -1,10 +1,15 @@
 module.exports = {
   parser: '@typescript-eslint/parser',
 
-  parserOptions: {
-    // Should always to the latest release (not pre-release) here:
+  env: {
+    // Specifying the ES version automatically sets the correct parser option.
+    // https://eslint.org/docs/user-guide/configuring/language-options#specifying-environments
+    // For TypeScript, this should always be the latest release (not pre-release) here:
     // https://github.com/tc39/ecma262/releases
-    ecmaVersion: 2020,
+    es2020: true,
+  },
+
+  parserOptions: {
     sourceType: 'module',
   },
 


### PR DESCRIPTION
Per [the docs](https://eslint.org/docs/user-guide/configuring/language-options#specifying-environments), we should just use `env`, and we failed to include appropriate globals in #149.