### PR TITLE
add prettierrc.yml

### DIFF
--- a/.prettierrc.yml
+++ b/.prettierrc.yml
@@ -1,0 +1,3 @@
+singleQuote: true
+trailingComma: all
+quoteProps: consistent


### PR DESCRIPTION
### preface
I have prettier for vscode installed with the option set to not format if a configuration file cannot be found.

I noticed, however, that on save it was turning single quote strings to double quote, which then showed as an error due to our eslint config.

Because this repo has an `.editorconfig` file, the prettier vscode plugin says "oh okay you really want me to format your files" and it follows the specs of that file. So I added the `.prettierrc.yml` file to prevent this behavior for anyone who might have my same experience. 