### PR TITLE
Add linting packages to root devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,12 @@
     "packages/*"
   ],
   "devDependencies": {
+    "eslint": "^7.23.0",
     "eslint-config-prettier": "^8.1.0",
-    "lerna": "^4.0.0"
+    "eslint-plugin-import": "^2.22.1",
+    "eslint-plugin-node": "^11.1.0",
+    "eslint-plugin-prettier": "^3.3.1",
+    "lerna": "^4.0.0",
+    "prettier": "^2.2.1"
   }
 }


### PR DESCRIPTION
Adds the linting packages required for linting to the root manifest's `devDependencies`. Ref: https://github.com/MetaMask/eslint-config/pull/152#issuecomment-811913372