### PR TITLE
Add release and utility scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,15 @@ extended configs, each package has a `rules-snapshot.json` fill which contains
 all rules of the particular config and its extended configs in a single
 dictionary. When editing a package, always check its rules snapshots after
 running `yarn lint:fix` to understand which rules changed.
+
+## Releasing
+
+The `@metamask/eslint-config` are version-locked.
+If you bump the version of one, you must bump the version of them all.
+When `main` is in a state that you want to release, complete the following steps:
+
+- Run `yarn create-release-pr <patch|minor|major>`
+  - This will bump the version of all packages and create a PR with a new patch, minor, or major version, per the argument given.
+- Update the changelogs of the packages that changed and push the changelog updates to the release PR
+- Once the release PR is merged, pull `main` and run `yarn publish-all`
+  - This will publish new versions of all packages.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,11 @@
     "lint:eslint": "yarn eslint . --ext ts,js",
     "lint:config-validation": "node ./scripts/validate-configs.js",
     "lint": "yarn lint:eslint && yarn lint:config-validation",
-    "lint:fix": "yarn lint:eslint --fix && yarn lint:config-validation --write"
+    "lint:fix": "yarn lint:eslint --fix && yarn lint:config-validation --write",
+    "link-packages": "./scripts/link-packages.sh",
+    "create-release-pr": "./scripts/create-release-pr.sh",
+    "prepare": "yarn lint",
+    "publish-all": "lerna publish from-package"
   },
   "workspaces": [
     "packages/*"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lint:fix": "yarn lint:eslint --fix && yarn lint:config-validation --write",
     "link-packages": "./scripts/link-packages.sh",
     "create-release-pr": "./scripts/create-release-pr.sh",
-    "prepare": "yarn lint",
+    "prepublishOnly": "yarn lint",
     "publish-all": "lerna publish from-package"
   },
   "workspaces": [

--- a/scripts/create-release-pr.sh
+++ b/scripts/create-release-pr.sh
@@ -14,10 +14,13 @@ function push_version_bump() {
   local newVersion
   newVersion=$(node -p 'require("./lerna.json").version')
 
-  git checkout -b "${newVersion}"
+  local branchName
+  branchName="release-v${newVersion}"
+
+  git checkout -b "${branchName}"
   git add .
-  git commit -m "${newVersion}" || true
-  git push -u origin "${newVersion}"
+  git commit -m "${branchName}" || true
+  git push -u origin "${branchName}"
 }
 
 # bump version of all packages

--- a/scripts/create-release-pr.sh
+++ b/scripts/create-release-pr.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -e
+set -u
+set -o pipefail
+
+if [ -z "${1:-}" ]
+then
+  echo "Error: Missing required positional argument: patch|minor|major"
+  exit 1
+fi
+
+function push_version_bump() {
+  local newVersion
+  newVersion=$(node -p 'require("./lerna.json").version')
+
+  git checkout -b "${newVersion}"
+  git add .
+  git commit -m "${newVersion}" || true
+  git push -u origin "${newVersion}"
+}
+
+# bump version of all packages
+lerna version "$1" --no-git-tag-version
+
+# get new version, create and push release branch
+push_version_bump

--- a/scripts/create-release-pr.sh
+++ b/scripts/create-release-pr.sh
@@ -19,7 +19,7 @@ function push_version_bump() {
 
   git checkout -b "${branchName}"
   git add .
-  git commit -m "${branchName}" || true
+  git commit -m "${newVersion}"
   git push -u origin "${branchName}"
 }
 

--- a/scripts/link-packages.sh
+++ b/scripts/link-packages.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -x
+set -e
+set -u
+set -o pipefail
+
+cd ./packages
+
+# ref: https://github.com/koalaman/shellcheck/wiki/SC2044
+# We swallow the output of "yarn unlink" because we don't care if it fails
+find . -mindepth 1 -maxdepth 1 -type d -exec sh -c '
+    cd "$1"
+    ! yarn unlink &> /dev/null
+    yarn link
+  ' sh {} \;


### PR DESCRIPTION
This PR establishes a version-locked release process for our ESLint config packages.

Adds the following bash scripts, with corresponding shortcuts in `package.json`:

- `scripts/create-release-pr.sh`, which bumps the version of all packages and creates a PR with the changes
- `scripts/link-packages.sh`, which runs `yarn link` in all packages, for development purposes

In addition, adds the following scripts to `package.json`:
- `prepublishOnly` (ref: https://github.com/lerna/lerna/tree/main/commands/publish#lifecycle-scripts)
- `publish-all`, which calls `lerna publish from-package`, intended to be used after merging a release PR created using `scripts/create-release-pr.sh`

The release process is described in a new `Releasing` section in the root readme.

### TODO

- Do we need to update the changelogs of every package for every release, even if a package is unchanged?