### PR TITLE
6.0.0

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "5.0.0",
+  "version": "6.0.0",
   "command": {
     "publish": {
       "registry": "https://registry.npmjs.org"

--- a/packages/base/CHANGELOG.md
+++ b/packages/base/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Changed
 
+- **(BREAKING)** Set minimum Node.js version to `^12.0.0` ([#144](https://github.com/MetaMask/eslint-config/pull/144))
 - **(BREAKING)** Add the [Prettier](https://prettier.io) ESLint plugin and extend the recommended Prettier ESLint config ([#96](https://github.com/MetaMask/eslint-config/pull/96))
   - See [here](https://github.com/prettier/eslint-plugin-prettier/blob/d993f24/eslint-plugin-prettier.js#L62-L73) for the `eslint-plugin-prettier` rules and [here](https://github.com/prettier/eslint-config-prettier/blob/abf3ba1/index.js) for the rules of `eslint-config-prettier`, which the plugin extends.
   - The rules of this config should otherwise be unchanged.

--- a/packages/base/CHANGELOG.md
+++ b/packages/base/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## Changed
 
 - **(BREAKING)** Set minimum Node.js version to `^12.0.0` ([#144](https://github.com/MetaMask/eslint-config/pull/144))
+- **(BREAKING)** Set ECMAScript version to `es2017`/`8` ([#150](https://github.com/MetaMask/eslint-config/pull/150))
 - **(BREAKING)** Add the [Prettier](https://prettier.io) ESLint plugin and extend the recommended Prettier ESLint config ([#96](https://github.com/MetaMask/eslint-config/pull/96))
   - See [here](https://github.com/prettier/eslint-plugin-prettier/blob/d993f24/eslint-plugin-prettier.js#L62-L73) for the `eslint-plugin-prettier` rules and [here](https://github.com/prettier/eslint-config-prettier/blob/abf3ba1/index.js) for the rules of `eslint-config-prettier`, which the plugin extends.
   - The rules of this config should otherwise be unchanged.

--- a/packages/base/CHANGELOG.md
+++ b/packages/base/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## Changed
 
 - **(BREAKING)** Add the [Prettier](https://prettier.io) ESLint plugin and extend the recommended Prettier ESLint config ([#96](https://github.com/MetaMask/eslint-config/pull/96))
+  - See [here](https://github.com/prettier/eslint-plugin-prettier/blob/d993f24/eslint-plugin-prettier.js#L62-L73) for the `eslint-plugin-prettier` rules and [here](https://github.com/prettier/eslint-config-prettier/blob/abf3ba1/index.js) for the rules of `eslint-config-prettier`, which the plugin extends.
   - The rules of this config should otherwise be unchanged.
 
 ## Removed

--- a/packages/base/CHANGELOG.md
+++ b/packages/base/CHANGELOG.md
@@ -6,13 +6,30 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [6.0.0] - 2021-04-08
+
+## Changed
+
+- **(BREAKING)** Add the [Prettier](https://prettier.io) ESLint plugin and extend the recommended Prettier ESLint config ([#96](https://github.com/MetaMask/eslint-config/pull/96))
+  - The rules of this config should otherwise be unchanged.
+
+## Removed
+
+- **(BREAKING)** All configs except the base config ([#141](https://github.com/MetaMask/eslint-config/pull/141))
+  - All configs are now published as separate packages, and must be extended by referencing their package names:
+    - [`@metamask/eslint-config`](https://npmjs.com/package/@metamask/eslint-config) (the base config)
+    - [`@metamask/eslint-config-jest`](https://npmjs.com/package/@metamask/eslint-config-jest)
+    - [`@metamask/eslint-config-mocha`](https://npmjs.com/package/@metamask/eslint-config-mocha)
+    - [`@metamask/eslint-config-nodejs`](https://npmjs.com/package/@metamask/eslint-config-nodejs)
+    - [`@metamask/eslint-config-typescript`](https://npmjs.com/package/@metamask/eslint-config-typescript)
+
 ## [5.0.0] - 2021-02-02
 
 ### Changed
 
-- **BREAKING:** Enable `semi` in base config ([#101](https://github.com/MetaMask/eslint-config/pull/101))
-- **BREAKING:** Disallow spaces before parentheses of named functions ([#101](https://github.com/MetaMask/eslint-config/pull/101))
-- **BREAKING:** Upgrade to TypeScript v4 and corresponding `@typescript-eslint` dependencies ([#79](https://github.com/MetaMask/eslint-config/pull/79), [#80](https://github.com/MetaMask/eslint-config/pull/80), [#103](https://github.com/MetaMask/eslint-config/pull/103))
+- **(BREAKING)** Enable `semi` in base config ([#101](https://github.com/MetaMask/eslint-config/pull/101))
+- **(BREAKING)** Disallow spaces before parentheses of named functions ([#101](https://github.com/MetaMask/eslint-config/pull/101))
+- **(BREAKING)** Upgrade to TypeScript v4 and corresponding `@typescript-eslint` dependencies ([#79](https://github.com/MetaMask/eslint-config/pull/79), [#80](https://github.com/MetaMask/eslint-config/pull/80), [#103](https://github.com/MetaMask/eslint-config/pull/103))
 
 ## [4.1.0] - 2020-10-21
 
@@ -25,7 +42,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 
-- **BREAKING:** Update to ESLint v7 (#46, #58, #62, #63)
+- **(BREAKING)** Update to ESLint v7 (#46, #58, #62, #63)
 - Relax `member-delimiter-style` for TypeScript ([#68](https://github.com/MetaMask/eslint-config/pull/68))
 - Disable `space-before-function-paren` for TypeScript ([#65](https://github.com/MetaMask/eslint-config/pull/65))
 
@@ -101,7 +118,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Add base, TypeScript, and Jest configs (#3)
 
-[Unreleased]:https://github.com/MetaMask/eslint-config/compare/v5.0.0...HEAD
+[Unreleased]:https://github.com/MetaMask/eslint-config/compare/v6.0.0...HEAD
+[6.0.0]:https://github.com/MetaMask/eslint-config/compare/v5.0.0...v6.0.0
 [5.0.0]:https://github.com/MetaMask/eslint-config/compare/v4.1.0...v5.0.0
 [4.1.0]:https://github.com/MetaMask/eslint-config/compare/v4.0.0...v4.1.0
 [4.0.0]:https://github.com/MetaMask/eslint-config/compare/v3.2.0...v4.0.0

--- a/packages/base/CHANGELOG.md
+++ b/packages/base/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - **(BREAKING)** Add the [Prettier](https://prettier.io) ESLint plugin and extend the recommended Prettier ESLint config ([#96](https://github.com/MetaMask/eslint-config/pull/96))
   - See [here](https://github.com/prettier/eslint-plugin-prettier/blob/d993f24/eslint-plugin-prettier.js#L62-L73) for the `eslint-plugin-prettier` rules and [here](https://github.com/prettier/eslint-config-prettier/blob/abf3ba1/index.js) for the rules of `eslint-config-prettier`, which the plugin extends.
   - The rules of this config should otherwise be unchanged.
+- Update `eslint` and other ESLint peer dependencies ([#151](https://github.com/MetaMask/eslint-config/pull/151))
 
 ## Removed
 

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/eslint-config",
-  "version": "5.0.0",
+  "version": "6.0.0",
   "description": "Shareable MetaMask ESLint config.",
   "main": "src/index.js",
   "publishConfig": {

--- a/packages/jest/CHANGELOG.md
+++ b/packages/jest/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   - The contents of this package were previously published as part of [`@metamask/eslint-config`](https://npmjs.com/package/@metamask/eslint-config).
   For changes prior to version `6.0.0`, please refer to the changelog of that package.
   - To continue extending this config, install this package and update your `.eslintrc.js` `extends` array to include `@metamask/eslint-config-jest` instead of `@metamask/eslint-config/jest`.
+- Update `eslint` and other ESLint peer dependencies ([#151](https://github.com/MetaMask/eslint-config/pull/151))
 
 [Unreleased]:https://github.com/MetaMask/eslint-config/compare/v6.0.0...HEAD
 [6.0.0]:https://github.com/MetaMask/eslint-config/tree/v6.0.0

--- a/packages/jest/CHANGELOG.md
+++ b/packages/jest/CHANGELOG.md
@@ -6,8 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
-The contents of this package were previosly published as part of [`@metamask/eslint-config`](https://npmjs.com/package/@metamask/eslint-config).
-For changes prior to version `6.0.0`, please refer to the changelog of that package.
+## [6.0.0] - 2021-04-08
 
-[Unreleased]:https://github.com/MetaMask/eslint-config/compare/v5.0.0...HEAD
-<!-- [6.0.0]:https://github.com/MetaMask/eslint-config/tree/v6.0.0 -->
+### Changed
+
+- Publish this config as its own package ([#141](https://github.com/MetaMask/eslint-config/pull/141))
+  - The contents of this package were previously published as part of [`@metamask/eslint-config`](https://npmjs.com/package/@metamask/eslint-config).
+  For changes prior to version `6.0.0`, please refer to the changelog of that package.
+  - To continue extending this config, install this package and update your `.eslintrc.js` `extends` array to include `@metamask/eslint-config-jest` instead of `@metamask/eslint-config/jest`.
+
+[Unreleased]:https://github.com/MetaMask/eslint-config/compare/v6.0.0...HEAD
+[6.0.0]:https://github.com/MetaMask/eslint-config/tree/v6.0.0

--- a/packages/jest/CHANGELOG.md
+++ b/packages/jest/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 
+- **(BREAKING)** Set minimum Node.js version to `^12.0.0` ([#144](https://github.com/MetaMask/eslint-config/pull/144))
 - Publish this config as its own package ([#141](https://github.com/MetaMask/eslint-config/pull/141))
   - The contents of this package were previously published as part of [`@metamask/eslint-config`](https://npmjs.com/package/@metamask/eslint-config).
   For changes prior to version `6.0.0`, please refer to the changelog of that package.

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/eslint-config-jest",
-  "version": "5.0.0",
+  "version": "6.0.0",
   "description": "Shareable MetaMask ESLint config for Jest.",
   "main": "src/index.js",
   "publishConfig": {

--- a/packages/mocha/CHANGELOG.md
+++ b/packages/mocha/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   - The contents of this package were previously published as part of [`@metamask/eslint-config`](https://npmjs.com/package/@metamask/eslint-config).
   For changes prior to version `6.0.0`, please refer to the changelog of that package.
   - To continue extending this config, install this package and update your `.eslintrc.js` `extends` array to include `@metamask/eslint-config-mocha` instead of `@metamask/eslint-config/mocha`.
+- Update `eslint` and other ESLint peer dependencies ([#151](https://github.com/MetaMask/eslint-config/pull/151))
 
 [Unreleased]:https://github.com/MetaMask/eslint-config/compare/v6.0.0...HEAD
 [6.0.0]:https://github.com/MetaMask/eslint-config/tree/v6.0.0

--- a/packages/mocha/CHANGELOG.md
+++ b/packages/mocha/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 
+- **(BREAKING)** Set minimum Node.js version to `^12.0.0` ([#144](https://github.com/MetaMask/eslint-config/pull/144))
 - **(BREAKING)** Enable [`mocha/no-exports`](https://github.com/lo1tuma/eslint-plugin-mocha/blob/bb203bc/docs/rules/no-exports.md) ([#156](https://github.com/MetaMask/eslint-config/pull/156))
 - Publish this config as its own package ([#141](https://github.com/MetaMask/eslint-config/pull/141))
   - The contents of this package were previously published as part of [`@metamask/eslint-config`](https://npmjs.com/package/@metamask/eslint-config).

--- a/packages/mocha/CHANGELOG.md
+++ b/packages/mocha/CHANGELOG.md
@@ -4,10 +4,15 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [6.0.0] - 2021-04-08
 
-The contents of this package were previosly published as part of [`@metamask/eslint-config`](https://npmjs.com/package/@metamask/eslint-config).
-For changes prior to version `6.0.0`, please refer to the changelog of that package.
+### Changed
 
-[Unreleased]:https://github.com/MetaMask/eslint-config/compare/v5.0.0...HEAD
-<!-- [6.0.0]:https://github.com/MetaMask/eslint-config/tree/v6.0.0 -->
+- **(BREAKING)** Enable [`mocha/no-exports`](https://github.com/lo1tuma/eslint-plugin-mocha/blob/bb203bc/docs/rules/no-exports.md) ([#156](https://github.com/MetaMask/eslint-config/pull/156))
+- Publish this config as its own package ([#141](https://github.com/MetaMask/eslint-config/pull/141))
+  - The contents of this package were previously published as part of [`@metamask/eslint-config`](https://npmjs.com/package/@metamask/eslint-config).
+  For changes prior to version `6.0.0`, please refer to the changelog of that package.
+  - To continue extending this config, install this package and update your `.eslintrc.js` `extends` array to include `@metamask/eslint-config-mocha` instead of `@metamask/eslint-config/mocha`.
+
+[Unreleased]:https://github.com/MetaMask/eslint-config/compare/v6.0.0...HEAD
+[6.0.0]:https://github.com/MetaMask/eslint-config/tree/v6.0.0

--- a/packages/mocha/package.json
+++ b/packages/mocha/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/eslint-config-mocha",
-  "version": "5.0.0",
+  "version": "6.0.0",
   "description": "Shareable MetaMask ESLint config for Mocha.",
   "main": "src/index.js",
   "publishConfig": {

--- a/packages/nodejs/CHANGELOG.md
+++ b/packages/nodejs/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   - The contents of this package were previously published as part of [`@metamask/eslint-config`](https://npmjs.com/package/@metamask/eslint-config).
   For changes prior to version `6.0.0`, please refer to the changelog of that package.
   - To continue extending this config, install this package and update your `.eslintrc.js` `extends` array to include `@metamask/eslint-config-nodejs` instead of `@metamask/eslint-config/nodejs`.
+- Update `eslint` and other ESLint peer dependencies ([#151](https://github.com/MetaMask/eslint-config/pull/151))
 
 [Unreleased]:https://github.com/MetaMask/eslint-config/compare/v6.0.0...HEAD
 [6.0.0]:https://github.com/MetaMask/eslint-config/tree/v6.0.0

--- a/packages/nodejs/CHANGELOG.md
+++ b/packages/nodejs/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 
+- **(BREAKING)** Set minimum Node.js version to `^12.0.0` ([#144](https://github.com/MetaMask/eslint-config/pull/144))
 - Publish this config as its own package ([#141](https://github.com/MetaMask/eslint-config/pull/141))
   - The contents of this package were previously published as part of [`@metamask/eslint-config`](https://npmjs.com/package/@metamask/eslint-config).
   For changes prior to version `6.0.0`, please refer to the changelog of that package.

--- a/packages/nodejs/CHANGELOG.md
+++ b/packages/nodejs/CHANGELOG.md
@@ -6,8 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
-The contents of this package were previosly published as part of [`@metamask/eslint-config`](https://npmjs.com/package/@metamask/eslint-config).
-For changes prior to version `6.0.0`, please refer to the changelog of that package.
+## [6.0.0] - 2021-04-08
 
-[Unreleased]:https://github.com/MetaMask/eslint-config/compare/v5.0.0...HEAD
-<!-- [6.0.0]:https://github.com/MetaMask/eslint-config/tree/v6.0.0 -->
+### Changed
+
+- Publish this config as its own package ([#141](https://github.com/MetaMask/eslint-config/pull/141))
+  - The contents of this package were previously published as part of [`@metamask/eslint-config`](https://npmjs.com/package/@metamask/eslint-config).
+  For changes prior to version `6.0.0`, please refer to the changelog of that package.
+  - To continue extending this config, install this package and update your `.eslintrc.js` `extends` array to include `@metamask/eslint-config-nodejs` instead of `@metamask/eslint-config/nodejs`.
+
+[Unreleased]:https://github.com/MetaMask/eslint-config/compare/v6.0.0...HEAD
+[6.0.0]:https://github.com/MetaMask/eslint-config/tree/v6.0.0

--- a/packages/nodejs/package.json
+++ b/packages/nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/eslint-config-nodejs",
-  "version": "5.0.0",
+  "version": "6.0.0",
   "description": "Shareable MetaMask ESLint config for Node.js.",
   "main": "src/index.js",
   "publishConfig": {

--- a/packages/typescript/CHANGELOG.md
+++ b/packages/typescript/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   - The contents of this package were previously published as part of [`@metamask/eslint-config`](https://npmjs.com/package/@metamask/eslint-config).
   For changes prior to version `6.0.0`, please refer to the changelog of that package.
   - To continue extending this config, install this package and update your `.eslintrc.js` `extends` array to include `@metamask/eslint-config-typescript` instead of `@metamask/eslint-config/typescript`.
+- Update `eslint` and other ESLint peer dependencies ([#151](https://github.com/MetaMask/eslint-config/pull/151))
 
 [Unreleased]:https://github.com/MetaMask/eslint-config/compare/v6.0.0...HEAD
 [6.0.0]:https://github.com/MetaMask/eslint-config/tree/v6.0.0

--- a/packages/typescript/CHANGELOG.md
+++ b/packages/typescript/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 
 - **(BREAKING)** Set minimum Node.js version to `^12.0.0` ([#144](https://github.com/MetaMask/eslint-config/pull/144))
+- **(BREAKING)** Set ECMAScript version to `es2020`/`11` ([#150](https://github.com/MetaMask/eslint-config/pull/150))
 - **(BREAKING)** Enable all rules recommended by the `@typescript-eslint` plugin ([#156](https://github.com/MetaMask/eslint-config/pull/156))
   - This amounted to setting the following core ESLint rules to `error`:
     - [no-var](https://eslint.org/docs/7.0.0/rules/no-var)

--- a/packages/typescript/CHANGELOG.md
+++ b/packages/typescript/CHANGELOG.md
@@ -6,8 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
-The contents of this package were previosly published as part of [`@metamask/eslint-config`](https://npmjs.com/package/@metamask/eslint-config).
-For changes prior to version `6.0.0`, please refer to the changelog of that package.
+## [6.0.0] - 2021-04-08
 
-[Unreleased]:https://github.com/MetaMask/eslint-config/compare/v5.0.0...HEAD
-<!-- [6.0.0]:https://github.com/MetaMask/eslint-config/tree/v6.0.0 -->
+### Changed
+
+- **(BREAKING)** Enable all rules recommended by the `@typescript-eslint` plugin ([#156](https://github.com/MetaMask/eslint-config/pull/156))
+  - This amounted to setting the following core ESLint rules to `error`:
+    - [no-var](https://eslint.org/docs/7.0.0/rules/no-var)
+    - [prefer-const](https://eslint.org/docs/7.0.0/rules/prefer-const)
+    - [prefer-rest-params](https://eslint.org/docs/7.0.0/rules/prefer-rest-params)
+    - [prefer-spread](https://eslint.org/docs/7.0.0/rules/prefer-spread)
+- Publish this config as its own package ([#141](https://github.com/MetaMask/eslint-config/pull/141))
+  - The contents of this package were previously published as part of [`@metamask/eslint-config`](https://npmjs.com/package/@metamask/eslint-config).
+  For changes prior to version `6.0.0`, please refer to the changelog of that package.
+  - To continue extending this config, install this package and update your `.eslintrc.js` `extends` array to include `@metamask/eslint-config-typescript` instead of `@metamask/eslint-config/typescript`.
+
+[Unreleased]:https://github.com/MetaMask/eslint-config/compare/v6.0.0...HEAD
+[6.0.0]:https://github.com/MetaMask/eslint-config/tree/v6.0.0

--- a/packages/typescript/CHANGELOG.md
+++ b/packages/typescript/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 
+- **(BREAKING)** Set minimum Node.js version to `^12.0.0` ([#144](https://github.com/MetaMask/eslint-config/pull/144))
 - **(BREAKING)** Enable all rules recommended by the `@typescript-eslint` plugin ([#156](https://github.com/MetaMask/eslint-config/pull/156))
   - This amounted to setting the following core ESLint rules to `error`:
     - [no-var](https://eslint.org/docs/7.0.0/rules/no-var)

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/eslint-config-typescript",
-  "version": "5.0.0",
+  "version": "6.0.0",
   "description": "Shareable MetaMask ESLint config for TypeScript.",
   "main": "src/index.js",
   "publishConfig": {


### PR DESCRIPTION
- Bump all packages to `6.0.0`
- Update changelogs
  - Most [commits](https://github.com/MetaMask/eslint-config/commits) aren't relevant to the consumer, so there weren't that many to flag.