### PR TITLE
Update no-shadow config

### DIFF
--- a/packages/base/rules-snapshot.json
+++ b/packages/base/rules-snapshot.json
@@ -264,8 +264,7 @@
   "no-shadow": [
     "error",
     {
-      "builtinGlobals": true,
-      "hoist": "functions"
+      "builtinGlobals": true
     }
   ],
   "no-shadow-restricted-names": "error",

--- a/packages/base/rules-snapshot.json
+++ b/packages/base/rules-snapshot.json
@@ -261,7 +261,13 @@
   "no-self-assign": "error",
   "no-self-compare": "error",
   "no-setter-return": "error",
-  "no-shadow": "error",
+  "no-shadow": [
+    "error",
+    {
+      "builtinGlobals": true,
+      "hoist": "functions"
+    }
+  ],
   "no-shadow-restricted-names": "error",
   "no-space-before-semi": "off",
   "no-spaced-func": "off",

--- a/packages/base/src/index.js
+++ b/packages/base/src/index.js
@@ -143,7 +143,7 @@ module.exports = {
     'no-return-assign': ['error', 'except-parens'],
     'no-script-url': 'error',
     'no-self-compare': 'error',
-    'no-shadow': 'error',
+    'no-shadow': ['error', { builtinGlobals: true, hoist: 'functions' }],
     'no-template-curly-in-string': 'error',
     'no-throw-literal': 'error',
     'no-undef-init': 'error',

--- a/packages/base/src/index.js
+++ b/packages/base/src/index.js
@@ -143,7 +143,7 @@ module.exports = {
     'no-return-assign': ['error', 'except-parens'],
     'no-script-url': 'error',
     'no-self-compare': 'error',
-    'no-shadow': ['error', { builtinGlobals: true, hoist: 'functions' }],
+    'no-shadow': ['error', { builtinGlobals: true }],
     'no-template-curly-in-string': 'error',
     'no-throw-literal': 'error',
     'no-undef-init': 'error',

--- a/packages/typescript/rules-snapshot.json
+++ b/packages/typescript/rules-snapshot.json
@@ -29,8 +29,7 @@
   "@typescript-eslint/no-shadow": [
     "error",
     {
-      "builtinGlobals": true,
-      "hoist": "functions"
+      "builtinGlobals": true
     }
   ],
   "@typescript-eslint/no-this-alias": "error",

--- a/packages/typescript/rules-snapshot.json
+++ b/packages/typescript/rules-snapshot.json
@@ -26,6 +26,13 @@
   "@typescript-eslint/no-non-null-assertion": "error",
   "@typescript-eslint/no-parameter-properties": "error",
   "@typescript-eslint/no-require-imports": "error",
+  "@typescript-eslint/no-shadow": [
+    "error",
+    {
+      "builtinGlobals": true,
+      "hoist": "functions"
+    }
+  ],
   "@typescript-eslint/no-this-alias": "error",
   "@typescript-eslint/no-unused-expressions": [
     "error",
@@ -74,6 +81,7 @@
   "no-obj-calls": "off",
   "no-redeclare": "off",
   "no-setter-return": "off",
+  "no-shadow": "off",
   "no-this-before-super": "off",
   "no-undef": "off",
   "no-unreachable": "off",

--- a/packages/typescript/src/index.js
+++ b/packages/typescript/src/index.js
@@ -51,10 +51,7 @@ module.exports = {
     '@typescript-eslint/default-param-last': 'error',
 
     'no-shadow': 'off',
-    '@typescript-eslint/no-shadow': [
-      'error',
-      { builtinGlobals: true, hoist: 'functions' },
-    ],
+    '@typescript-eslint/no-shadow': ['error', { builtinGlobals: true }],
 
     'no-unused-expressions': 'off',
     '@typescript-eslint/no-unused-expressions': [

--- a/packages/typescript/src/index.js
+++ b/packages/typescript/src/index.js
@@ -50,6 +50,12 @@ module.exports = {
     'default-param-last': 'off',
     '@typescript-eslint/default-param-last': 'error',
 
+    'no-shadow': 'off',
+    '@typescript-eslint/no-shadow': [
+      'error',
+      { builtinGlobals: true, hoist: 'functions' },
+    ],
+
     'no-unused-expressions': 'off',
     '@typescript-eslint/no-unused-expressions': [
       'error',

--- a/packages/typescript/src/index.js
+++ b/packages/typescript/src/index.js
@@ -21,6 +21,10 @@ module.exports = {
     // Should be disabled per Prettier
     '@typescript-eslint/no-extra-semi': 'off',
 
+    // Handled by TypeScript
+    'import/no-unresolved': 'off',
+
+    // Our rules
     '@typescript-eslint/array-type': 'error',
     '@typescript-eslint/consistent-type-assertions': 'error',
     '@typescript-eslint/consistent-type-definitions': 'error',
@@ -43,22 +47,19 @@ module.exports = {
       { vars: 'all', args: 'all', argsIgnorePattern: '[_]+' },
     ],
 
-    '@typescript-eslint/default-param-last': 'error',
     'default-param-last': 'off',
+    '@typescript-eslint/default-param-last': 'error',
 
+    'no-unused-expressions': 'off',
     '@typescript-eslint/no-unused-expressions': [
       'error',
       { allowShortCircuit: true, allowTernary: true },
     ],
-    'no-unused-expressions': 'off',
 
-    '@typescript-eslint/no-use-before-define': ['error', { functions: false }],
     'no-use-before-define': 'off',
+    '@typescript-eslint/no-use-before-define': ['error', { functions: false }],
 
-    '@typescript-eslint/no-useless-constructor': 'error',
     'no-useless-constructor': 'off',
-
-    // Handled by TypeScript
-    'import/no-unresolved': 'off',
+    '@typescript-eslint/no-useless-constructor': 'error',
   },
 };


### PR DESCRIPTION
This PR updates the configuration of [`no-shadow`](https://eslint.org/docs/7.0.0/rules/no-shadow) in the base config and replaces it with the `@typescript-eslint` version of the same rule to the TypeScript config.

The strictness of `no-shadow` is increased by forbidding the shadowing of built-in globals, e.g. `Object`, which for unknown reasons is permitted by default.

This probably makes the change breaking. Oh well.