### PR TITLE
Update install instructions in READMEs

### DIFF
--- a/packages/base/README.md
+++ b/packages/base/README.md
@@ -8,9 +8,12 @@ Our default export contains a base set of ESLint rules for ES6+:
 
 ```bash
 yarn add --dev \
+    @metamask/eslint-config@^6.0.0 \
     eslint@^7.23.0 \
-    eslint-plugin-import@^2.22.0 \
-    @metamask/eslint-config@^5.0.0
+    eslint-config-prettier@^8.1.0 \
+    eslint-plugin-import@^2.22.1 \
+    eslint-plugin-prettier@^3.3.1 \
+    prettier@^2.2.1
 ```
 
 The order in which you extend ESLint rules matters.

--- a/packages/jest/README.md
+++ b/packages/jest/README.md
@@ -6,11 +6,14 @@ MetaMask's [Jest](https://jestjs.io/) ESLint configuration.
 
 ```bash
 yarn add --dev \
+    @metamask/eslint-config@^6.0.0 \
+    @metamask/eslint-config-jest@^6.0.0 \
     eslint@^7.23.0 \
-    eslint-plugin-import@^2.22.0 \
-    eslint-plugin-jest@^23.6.0 \
-    @metamask/eslint-config@^5.0.0 \
-    @metamask/eslint-config-jest@^5.0.0
+    eslint-config-prettier@^8.1.0 \
+    eslint-plugin-import@^2.22.1 \
+    eslint-plugin-jest@^24.1.3 \
+    eslint-plugin-prettier@^3.3.1 \
+    prettier@^2.2.1
 ```
 
 The order in which you extend ESLint rules matters.

--- a/packages/mocha/README.md
+++ b/packages/mocha/README.md
@@ -6,11 +6,14 @@ MetaMask's [Mocha](https://mochajs.org/) ESLint configuration.
 
 ```bash
 yarn add --dev \
+    @metamask/eslint-config@^6.0.0 \
+    @metamask/eslint-config-mocha@^6.0.0 \
     eslint@^7.23.0 \
-    eslint-plugin-import@^2.22.0 \
-    eslint-plugin-mocha@^8.0.0 \
-    @metamask/eslint-config@^5.0.0 \
-    @metamask/eslint-config-mocha@^5.0.0
+    eslint-config-prettier@^8.1.0 \
+    eslint-plugin-import@^2.22.1 \
+    eslint-plugin-mocha@^8.1.0 \
+    eslint-plugin-prettier@^3.3.1 \
+    prettier@^2.2.1
 ```
 
 The order in which you extend ESLint rules matters.

--- a/packages/nodejs/README.md
+++ b/packages/nodejs/README.md
@@ -6,11 +6,15 @@ MetaMask's [Node.js](https://nodejs.org) ESLint configuration.
 
 ```bash
 yarn add --dev \
+    @metamask/eslint-config@^6.0.0 \
+    @metamask/eslint-config-nodejs@^6.0.0 \
     eslint@^7.23.0 \
-    eslint-plugin-import@^2.22.0 \
+    eslint-config-prettier@^8.1.0 \
+    eslint-plugin-import@^2.22.1 \
     eslint-plugin-node@^11.1.0 \
-    @metamask/eslint-config@^5.0.0 \
-    @metamask/eslint-config-nodejs@^5.0.0
+    eslint-plugin-prettier@^3.3.1 \
+    prettier@^2.2.1
+
 ```
 
 The order in which you extend ESLint rules matters.

--- a/packages/typescript/README.md
+++ b/packages/typescript/README.md
@@ -6,12 +6,16 @@ MetaMask's [TypeScript](https://www.typescriptlang.org) ESLint configuration.
 
 ```bash
 yarn add --dev \
+    @metamask/eslint-config@^6.0.0 \
+    @metamask/eslint-config-typescript@^6.0.0 \
+    @typescript-eslint/eslint-plugin@^4.20.0 \
+    @typescript-eslint/parser@^4.20.0 \
     eslint@^7.23.0 \
-    eslint-plugin-import@^2.22.0 \
-    @typescript-eslint/eslint-plugin@^3.9.1 \
-    @typescript-eslint/parser@^3.9.1 \
-    @metamask/eslint-config@^5.0.0 \
-    @metamask/eslint-config-typescript@^5.0.0
+    eslint-config-prettier@^8.1.0 \
+    eslint-plugin-import@^2.22.1 \
+    eslint-plugin-prettier@^3.3.1 \
+    prettier@^2.2.1
+
 ```
 
 The order in which you extend ESLint rules matters.


### PR DESCRIPTION
The install instructions for each package had not been updated for the v6 release. They have all been updated to reference the correct package versions.