### PR TITLE
Add base package as a peer dependency

### DIFF
--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -26,10 +26,12 @@
   },
   "homepage": "https://github.com/MetaMask/eslint-config#readme",
   "devDependencies": {
+    "@metamask/eslint-config": "^6.0.0",
     "eslint": "^7.23.0",
     "eslint-plugin-jest": "^24.1.3"
   },
   "peerDependencies": {
+    "@metamask/eslint-config": "^6.0.0",
     "eslint": "^7.23.0",
     "eslint-plugin-jest": "^24.1.3"
   }

--- a/packages/mocha/package.json
+++ b/packages/mocha/package.json
@@ -26,10 +26,12 @@
   },
   "homepage": "https://github.com/MetaMask/eslint-config#readme",
   "devDependencies": {
+    "@metamask/eslint-config": "^6.0.0",
     "eslint": "^7.23.0",
     "eslint-plugin-mocha": "^8.1.0"
   },
   "peerDependencies": {
+    "@metamask/eslint-config": "^6.0.0",
     "eslint": "^7.23.0",
     "eslint-plugin-mocha": "^8.1.0"
   }

--- a/packages/nodejs/package.json
+++ b/packages/nodejs/package.json
@@ -26,10 +26,12 @@
   },
   "homepage": "https://github.com/MetaMask/eslint-config#readme",
   "devDependencies": {
+    "@metamask/eslint-config": "^6.0.0",
     "eslint": "^7.23.0",
     "eslint-plugin-node": "^11.1.0"
   },
   "peerDependencies": {
+    "@metamask/eslint-config": "^6.0.0",
     "eslint": "^7.23.0",
     "eslint-plugin-node": "^11.1.0"
   }

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -26,12 +26,14 @@
   },
   "homepage": "https://github.com/MetaMask/eslint-config#readme",
   "devDependencies": {
+    "@metamask/eslint-config": "^6.0.0",
     "@typescript-eslint/eslint-plugin": "^4.20.0",
     "@typescript-eslint/parser": "^4.20.0",
     "eslint": "^7.23.0",
     "typescript": "^4.0.7"
   },
   "peerDependencies": {
+    "@metamask/eslint-config": "^6.0.0",
     "@typescript-eslint/eslint-plugin": "^4.20.0",
     "@typescript-eslint/parser": "^4.20.0",
     "eslint": "^7.23.0",


### PR DESCRIPTION
We generally assume that anyone using our environment-specific packages is also using our base package. Our config validation assumes this as well, ensuring that there are no duplicate rules between them. As a result, anyone _not_ using the base package might have problems.

The base package has been added as a peer dependency everywhere to ensure consumers are warned about omitting the base package.