### PR TITLE
Add publish script

### DIFF
--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -14,7 +14,8 @@
     "node": ">=12.0.0"
   },
   "scripts": {
-    "test": "eslint ."
+    "test": "eslint .",
+    "publish": "npm publish"
   },
   "repository": {
     "type": "git",

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -14,7 +14,8 @@
     "node": ">=12.0.0"
   },
   "scripts": {
-    "test": "eslint ."
+    "test": "eslint .",
+    "publish": "npm publish"
   },
   "repository": {
     "type": "git",

--- a/packages/mocha/package.json
+++ b/packages/mocha/package.json
@@ -14,7 +14,8 @@
     "node": ">=12.0.0"
   },
   "scripts": {
-    "test": "eslint ."
+    "test": "eslint .",
+    "publish": "npm publish"
   },
   "repository": {
     "type": "git",

--- a/packages/nodejs/package.json
+++ b/packages/nodejs/package.json
@@ -14,7 +14,8 @@
     "node": ">=12.0.0"
   },
   "scripts": {
-    "test": "eslint ."
+    "test": "eslint .",
+    "publish": "npm publish"
   },
   "repository": {
     "type": "git",

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -14,7 +14,8 @@
     "node": ">=12.0.0"
   },
   "scripts": {
-    "test": "eslint ."
+    "test": "eslint .",
+    "publish": "npm publish"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Adds a script named `publish` to every `package.json` file so that you can do e.g. `yarn workspace path/to/workspace run publish` and `yarn workspaces run publish`.