### PR TITLE
Fix parserOptions for various configs

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,24 +1,19 @@
 module.exports = {
   root: true,
 
+  parserOptions: {
+    ecmaVersion: 2018,
+  },
+
   extends: ['@metamask/eslint-config', '@metamask/eslint-config-nodejs'],
 
-  overrides: [
-    {
-      files: ['./scripts/*.js'],
-      parserOptions: {
-        ecmaVersion: 2018,
-        sourceType: 'script',
-      },
-      rules: {
-        'import/no-dynamic-require': 'off',
-        'node/global-require': 'off',
-        'node/no-process-exit': 'off',
-        'node/no-sync': 'off',
-        'node/no-unpublished-require': 'off',
-      },
-    },
-  ],
+  rules: {
+    'import/no-dynamic-require': 'off',
+    'node/global-require': 'off',
+    'node/no-process-exit': 'off',
+    'node/no-sync': 'off',
+    'node/no-unpublished-require': 'off',
+  },
 
   ignorePatterns: ['!.eslintrc.js'],
 };

--- a/packages/base/src/index.js
+++ b/packages/base/src/index.js
@@ -1,12 +1,21 @@
 module.exports = {
   env: {
-    // Specifying the ES version automatically sets the correct parser option.
-    // https://eslint.org/docs/user-guide/configuring/language-options#specifying-environments
+    // See comment under `parserOptions` below.
+    es2017: true,
+    'shared-node-browser': true,
+  },
+
+  parserOptions: {
+    // The `esXXXX` option under `env` is supposed to set the correct
+    // `ecmaVersion` option here, but we've had issues with it being
+    // overridden in the past and therefore set it explicitly.
+    //
     // For JavaScript, ES2017 is our effective minimum version due to the use
     // of Esprima by transitive dependencies.
     // It doesn't handle object rest spread, which is a 2018 feature.
-    es2017: true,
-    'shared-node-browser': true,
+    ecmaVersion: 2017,
+    // We want to default to 'script' and only use 'module' explicitly.
+    sourceType: 'script',
   },
 
   plugins: ['prettier'],

--- a/packages/nodejs/src/index.js
+++ b/packages/nodejs/src/index.js
@@ -2,7 +2,18 @@ module.exports = {
   plugins: ['node'],
 
   env: {
+    // See comment under `parserOptions` below.
+    es2017: true,
     node: true,
+  },
+
+  // The recommended Node.js plugin config sets the correct `sourceType` per the
+  // `type` field of the local package.json file, so we don't set that here.
+  parserOptions: {
+    // The EcmaScript version option here and for `env` above need to be set to
+    // the same values as in the base config, or they will be overwritten by the
+    // recommended Node.js plugin rules.
+    ecmaVersion: 2017,
   },
 
   extends: ['plugin:node/recommended'],

--- a/packages/typescript/src/index.js
+++ b/packages/typescript/src/index.js
@@ -2,14 +2,18 @@ module.exports = {
   parser: '@typescript-eslint/parser',
 
   env: {
-    // Specifying the ES version automatically sets the correct parser option.
-    // https://eslint.org/docs/user-guide/configuring/language-options#specifying-environments
-    // For TypeScript, this should always be the latest release (not pre-release) here:
-    // https://github.com/tc39/ecma262/releases
+    // See comment under `parserOptions` below.
     es2020: true,
   },
 
   parserOptions: {
+    // The `esXXXX` option under `env` is supposed to set the correct
+    // `ecmaVersion` option here, but we've had issues with it being
+    // overridden in the past and therefore set it explicitly.
+    //
+    // For TypeScript, the EcmaScript version always be the latest release
+    // (not pre-release) here: https://github.com/tc39/ecma262/releases
+    ecmaVersion: 2020,
     sourceType: 'module',
   },
 


### PR DESCRIPTION
After upgrading to `7.0.0` of these packages in a couple of repositories, we encountered unexpected `import/unambiguous` rule violations. The reason for this turned out to be that we unintentionally set `parserOptions.sourceType` to `module` in some configs by extending the recommended ruleset of `eslint-plugin-import`. For the sake of simplicity, and minimizing breaking changes, we have decided to use `sourceType: script` by default for JavaScript, and `module` for TypeScript.

While debugging the above issue, we also noticed that the EcmaScript version was incorrectly set in places, probably due to related issues. According to the ESLint documentation, setting `env.es2017 = true` should automatically set `parserOptions.ecmaVersion = 2017`. It appears that this behavior is overridden by plugins and/or extended configs. Therefore, we now set both `env.esXXXX` and `parserOptions.ecmaVersion` explicitly.