### PR TITLE
Require newlines between multiline blocks and expressions

### DIFF
--- a/packages/base/rules-snapshot.json
+++ b/packages/base/rules-snapshot.json
@@ -352,6 +352,17 @@
       "blankLine": "any",
       "prev": "directive",
       "next": "directive"
+    },
+    {
+      "blankLine": "always",
+      "prev": [
+        "multiline-block-like",
+        "multiline-expression"
+      ],
+      "next": [
+        "multiline-block-like",
+        "multiline-expression"
+      ]
     }
   ],
   "prefer-arrow-callback": "off",

--- a/packages/base/src/index.js
+++ b/packages/base/src/index.js
@@ -199,6 +199,11 @@ module.exports = {
         prev: 'directive',
         next: 'directive',
       },
+      {
+        blankLine: 'always',
+        prev: ['multiline-block-like', 'multiline-expression'],
+        next: ['multiline-block-like', 'multiline-expression'],
+      },
     ],
     'prefer-const': 'error',
     'prefer-destructuring': [


### PR DESCRIPTION
This PR adds another condition where we apply the `padding-line-between-statements`, namely between multiline blocks and expressions. Whenever we forget to manually add newlines between multiline blocks and expressions, our files become significantly less navigable for those of us that use vim. It also makes our files cramped and harder to read, especially tests. 

We already tend to do this in practice, so this is best viewed as enforcing an existing, informal standard.

By way of example, `multiline-block-like` option results in the following change:

```javascript
/// before

if (foo) {
  // stuff
}
if (bar) {
  // stuff
}

/// after

if (foo) {
  // stuff
}

if (bar) {
  // stuff
}
```

While the `multiline-expression` option results in the following:

```javascript
/// before

it('does thing one', () => {
  // stuff
})
it('does thing two', () => {
  // stuff
})

/// after

it('does thing one', () => {
  // stuff
})

it('does thing two', () => {
  // stuff
})
```