### PR TITLE
Fix no-throw-literal config for TypeScript

### DIFF
--- a/packages/typescript/rules-snapshot.json
+++ b/packages/typescript/rules-snapshot.json
@@ -33,6 +33,7 @@
     }
   ],
   "@typescript-eslint/no-this-alias": "error",
+  "@typescript-eslint/no-throw-literal": "error",
   "@typescript-eslint/no-unused-expressions": [
     "error",
     {
@@ -83,6 +84,7 @@
   "no-setter-return": "off",
   "no-shadow": "off",
   "no-this-before-super": "off",
+  "no-throw-literal": "off",
   "no-undef": "off",
   "no-unreachable": "off",
   "no-unsafe-negation": "off",

--- a/packages/typescript/src/index.js
+++ b/packages/typescript/src/index.js
@@ -60,6 +60,9 @@ module.exports = {
     'no-shadow': 'off',
     '@typescript-eslint/no-shadow': ['error', { builtinGlobals: true }],
 
+    'no-throw-literal': 'off',
+    '@typescript-eslint/no-throw-literal': 'error',
+
     'no-unused-expressions': 'off',
     '@typescript-eslint/no-unused-expressions': [
       'error',


### PR DESCRIPTION
Fixes the `no-throw-literal` rule configuration for TypeScript by enabling the appropriate rule in the TypeScript config, per [documentation](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-throw-literal.md#how-to-use).

This is timely due to recent [changes to TypeScript](https://github.com/microsoft/TypeScript/pull/41013).