### PR TITLE
Implement arrow-body-style to remove unnecessary return statements

### DIFF
--- a/packages/base/src/index.js
+++ b/packages/base/src/index.js
@@ -54,6 +54,7 @@ module.exports = {
     /* Core rules */
     'accessor-pairs': 'error',
     'array-callback-return': 'error',
+    'arrow-body-style': 'error',
     'block-scoped-var': 'error',
     camelcase: [
       'error',


### PR DESCRIPTION
As voted positively here: https://github.com/MetaMask/metamask-extension/pull/12127