### PR TITLE
Disable `@typescript-eslint/no-throw-literal`

### DIFF
--- a/packages/typescript/rules-snapshot.json
+++ b/packages/typescript/rules-snapshot.json
@@ -33,7 +33,6 @@
     }
   ],
   "@typescript-eslint/no-this-alias": "error",
-  "@typescript-eslint/no-throw-literal": "error",
   "@typescript-eslint/no-unused-expressions": [
     "error",
     {

--- a/packages/typescript/src/index.js
+++ b/packages/typescript/src/index.js
@@ -61,7 +61,7 @@ module.exports = {
     '@typescript-eslint/no-shadow': ['error', { builtinGlobals: true }],
 
     'no-throw-literal': 'off',
-    '@typescript-eslint/no-throw-literal': 'error',
+    // '@typescript-eslint/no-throw-literal' is left disabled because it requires type information
 
     'no-unused-expressions': 'off',
     '@typescript-eslint/no-unused-expressions': [


### PR DESCRIPTION
The rule `@typescript-eslint/no-throw-literal` has been disabled because it requires type information, which we hadn't realized when the rule was added. We're saving rules that require type information for a future release.

The rule that it extends (`no-throw-literal`) is left as disabled because it doesn't work properly with TypeScript (hence the existence of the extension rule).