### PR TITLE
Add missing change entries for v8

### DIFF
--- a/packages/jest/CHANGELOG.md
+++ b/packages/jest/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **BREAKING** Add JSDoc ESLint rules ([#203](https://github.com/MetaMask/eslint-config/pull/203))
 
 ## [8.0.0]
+### Changed
+- ***BREAKING*** The peer dependency `@metamask/eslint-config` has been updated from v7 to v8.
 
 ## [7.0.0]
 ### Changed

--- a/packages/mocha/CHANGELOG.md
+++ b/packages/mocha/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **BREAKING** Add JSDoc ESLint rules ([#203](https://github.com/MetaMask/eslint-config/pull/203))
 
 ## [8.0.0]
+### Changed
+- ***BREAKING*** The peer dependency `@metamask/eslint-config` has been updated from v7 to v8.
 
 ## [7.0.0]
 ### Changed

--- a/packages/nodejs/CHANGELOG.md
+++ b/packages/nodejs/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **BREAKING** Add JSDoc ESLint rules ([#203](https://github.com/MetaMask/eslint-config/pull/203))
 
 ## [8.0.0]
+### Changed
+- ***BREAKING*** The peer dependency `@metamask/eslint-config` has been updated from v7 to v8.
 
 ## [7.0.1]
 ### Fixed

--- a/packages/typescript/CHANGELOG.md
+++ b/packages/typescript/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Note: This change has been undone in v9.0.1. You can ignore this change if you're updating to v9.0.1 or greater.
 
 ## [8.0.0]
+### Changed
+- ***BREAKING*** The peer dependency `@metamask/eslint-config` has been updated from v7 to v8.
 
 ## [7.0.1]
 ### Fixed


### PR DESCRIPTION
The v8 entries for the non-base packages were left blank. They have been updated to explain the breaking change.