### PR TITLE
Ignore rest siblings for `no-unused-vars`

### DIFF
--- a/packages/base/rules-snapshot.json
+++ b/packages/base/rules-snapshot.json
@@ -340,7 +340,8 @@
     {
       "vars": "all",
       "args": "all",
-      "argsIgnorePattern": "[_]+"
+      "argsIgnorePattern": "[_]+",
+      "ignoreRestSiblings": true
     }
   ],
   "no-use-before-define": [

--- a/packages/base/src/index.js
+++ b/packages/base/src/index.js
@@ -163,6 +163,7 @@ module.exports = {
         vars: 'all',
         args: 'all',
         argsIgnorePattern: '[_]+',
+        ignoreRestSiblings: true,
       },
     ],
     'no-use-before-define': [

--- a/packages/typescript/rules-snapshot.json
+++ b/packages/typescript/rules-snapshot.json
@@ -45,7 +45,8 @@
     {
       "vars": "all",
       "args": "all",
-      "argsIgnorePattern": "[_]+"
+      "argsIgnorePattern": "[_]+",
+      "ignoreRestSiblings": true
     }
   ],
   "@typescript-eslint/no-use-before-define": [

--- a/packages/typescript/src/index.js
+++ b/packages/typescript/src/index.js
@@ -51,7 +51,12 @@ module.exports = {
     '@typescript-eslint/no-dupe-class-members': 'error',
     '@typescript-eslint/no-unused-vars': [
       'error',
-      { vars: 'all', args: 'all', argsIgnorePattern: '[_]+' },
+      {
+        vars: 'all',
+        args: 'all',
+        argsIgnorePattern: '[_]+',
+        ignoreRestSiblings: true,
+      },
     ],
 
     'default-param-last': 'off',


### PR DESCRIPTION
The `ignoreRestSiblings` rule has been enabled for the [`no-unused-vars` rule](https://eslint.org/docs/rules/no-unused-vars) and the [`@typescript-eslint/no-unused-vars` rule](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-unused-vars.md). This allows the use of unused variables alongside a rest operator. This pattern can be useful for excluding variables from a group that you don't want to use.

This option is [already in use in the `@metamask/controllers` repository](https://github.com/MetaMask/controllers/blob/8134da08a03fb63b146f8a3cffcb5e78fb70d58b/.eslintrc.js#L40).