### PR TITLE
Remove `@typescript-config/consistent-type-definition` rule

### DIFF
--- a/packages/typescript/rules-snapshot.json
+++ b/packages/typescript/rules-snapshot.json
@@ -4,7 +4,6 @@
   "@typescript-eslint/ban-ts-comment": "error",
   "@typescript-eslint/ban-types": "error",
   "@typescript-eslint/consistent-type-assertions": "error",
-  "@typescript-eslint/consistent-type-definitions": "error",
   "@typescript-eslint/default-param-last": "error",
   "@typescript-eslint/explicit-module-boundary-types": "off",
   "@typescript-eslint/no-array-constructor": "error",

--- a/packages/typescript/src/index.js
+++ b/packages/typescript/src/index.js
@@ -34,7 +34,6 @@ module.exports = {
     // Our rules
     '@typescript-eslint/array-type': 'error',
     '@typescript-eslint/consistent-type-assertions': 'error',
-    '@typescript-eslint/consistent-type-definitions': 'error',
     '@typescript-eslint/explicit-module-boundary-types': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
     '@typescript-eslint/no-namespace': [


### PR DESCRIPTION
The `@typescript-config/consistent-type-definition` rule has been removed because it tries to force the use of interfaces over types in scenarios where interfaces don't work due to [incompatibilities with `Record<string, unknown>`](https://github.com/Microsoft/TypeScript/issues/15300#issuecomment-702872440).

We could consider forcing the use of types over interfaces instead, but I prefer using interfaces in some situations. They seem simpler to write and understand sometimes. So for now it seems best to just remove the rule.

This rule has [already been disabled in the `@metamask/controllers` repository](https://github.com/MetaMask/controllers/blob/8134da08a03fb63b146f8a3cffcb5e78fb70d58b/.eslintrc.js#L36).