### PR TITLE
Forbid TypeScript interfaces

### DIFF
--- a/packages/typescript/rules-snapshot.json
+++ b/packages/typescript/rules-snapshot.json
@@ -4,7 +4,7 @@
   "@typescript-eslint/ban-ts-comment": "error",
   "@typescript-eslint/ban-types": "error",
   "@typescript-eslint/consistent-type-assertions": "error",
-  "@typescript-eslint/consistent-type-definitions": "error",
+  "@typescript-eslint/consistent-type-definitions": ["error", "type"],
   "@typescript-eslint/default-param-last": "error",
   "@typescript-eslint/explicit-module-boundary-types": "off",
   "@typescript-eslint/no-array-constructor": "error",

--- a/packages/typescript/src/index.js
+++ b/packages/typescript/src/index.js
@@ -34,7 +34,7 @@ module.exports = {
     // Our rules
     '@typescript-eslint/array-type': 'error',
     '@typescript-eslint/consistent-type-assertions': 'error',
-    '@typescript-eslint/consistent-type-definitions': 'error',
+    '@typescript-eslint/consistent-type-definitions': ['error', 'type'],
     '@typescript-eslint/explicit-module-boundary-types': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
     '@typescript-eslint/no-namespace': [


### PR DESCRIPTION
TypeScript interfaces suck, they don't work with our `Json` type, and it's high time that we abolish them from every part of our codebase.

To wit, the only thing that can be done with an interface that cannot be done with a type is [declaration merging](https://www.typescriptlang.org/docs/handbook/declaration-merging.html), which is a "good language feature" in much the same way that a knife without a handle is a "good cooking instrument". All of the actually good stuff – IMO first and foremost `extends` and `implements` – [is also supported by object types](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#differences-between-type-aliases-and-interfaces) (in this case, via `&` and `implements`).

So, if we have two language features A and B, where the capabilities of A are a strict superset of those of B, and using B at all will sometimes cause uses supported by A to fail, the only sane thing to do is get rid of B. "B" is interfaces. Long live interfaces!