### PR TITLE
Update Mocha ecmaVersion

### DIFF
--- a/packages/mocha/src/index.js
+++ b/packages/mocha/src/index.js
@@ -9,6 +9,10 @@ module.exports = {
 
   extends: ['plugin:mocha/recommended'],
 
+  parserOptions: {
+    ecmaVersion: '2020',
+  },
+
   rules: {
     'mocha/no-exclusive-tests': 'error',
     'mocha/no-hooks-for-single-case': 'error',


### PR DESCRIPTION
Updates the `mocha` config `parserOptions.ecmaVersion` to `2020`. This allows us to use ES2020 features such as the spread operator in all its varied forms in our Mocha tests. We don't have to worry about compatibility for our end users because we're of course not shipping our tests anyway.