### PR TITLE
BREAKING: Update `eslint-plugin-mocha` from v8 to v10

### DIFF
--- a/packages/mocha/package.json
+++ b/packages/mocha/package.json
@@ -29,11 +29,11 @@
   "devDependencies": {
     "@metamask/eslint-config": "^9.0.0",
     "eslint": "^7.23.0",
-    "eslint-plugin-mocha": "^8.1.0"
+    "eslint-plugin-mocha": "^10.1.0"
   },
   "peerDependencies": {
     "@metamask/eslint-config": "^9.0.0",
     "eslint": "^7.23.0",
-    "eslint-plugin-mocha": "^8.1.0"
+    "eslint-plugin-mocha": "^10.1.0"
   }
 }

--- a/packages/mocha/rules-snapshot.json
+++ b/packages/mocha/rules-snapshot.json
@@ -7,6 +7,7 @@
     }
   ],
   "mocha/no-async-describe": "error",
+  "mocha/no-empty-description": "error",
   "mocha/no-exclusive-tests": "error",
   "mocha/no-exports": "error",
   "mocha/no-global-tests": "error",

--- a/yarn.lock
+++ b/yarn.lock
@@ -758,13 +758,13 @@ eslint-plugin-jsdoc@^39.2.9:
     semver "^7.3.7"
     spdx-expression-parse "^3.0.1"
 
-eslint-plugin-mocha@^8.1.0:
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-mocha/-/eslint-plugin-mocha-8.1.0.tgz#b9aebbede46a808e46e622c8fd99d2a2f353e725"
-  integrity sha512-1EgHvXKRl7W3mq3sntZAi5T24agRMyiTPL4bSXe+B4GksYOjAPEWYx+J3eJg4It1l2NMNZJtk0gQyQ6mfiPhQg==
+eslint-plugin-mocha@^10.1.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-mocha/-/eslint-plugin-mocha-10.1.0.tgz#69325414f875be87fb2cb00b2ef33168d4eb7c8d"
+  integrity sha512-xLqqWUF17llsogVOC+8C6/jvQ+4IoOREbN7ZCHuOHuD6cT5cDD4h7f2LgsZuzMAiwswWE21tO7ExaknHVDrSkw==
   dependencies:
-    eslint-utils "^2.1.0"
-    ramda "^0.27.1"
+    eslint-utils "^3.0.0"
+    rambda "^7.1.0"
 
 eslint-plugin-node@^11.1.0:
   version "11.1.0"
@@ -799,6 +799,13 @@ eslint-utils@^2.0.0, eslint-utils@^2.1.0:
   integrity sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==
   dependencies:
     eslint-visitor-keys "^1.1.0"
+
+eslint-utils@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-3.0.0.tgz#8aebaface7345bb33559db0a1f13a1d2d48c3672"
+  integrity sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==
+  dependencies:
+    eslint-visitor-keys "^2.0.0"
 
 eslint-visitor-keys@^1.1.0, eslint-visitor-keys@^1.3.0:
   version "1.3.0"
@@ -1787,10 +1794,10 @@ qs@~6.5.2:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.3.tgz#3aeeffc91967ef6e35c0e488ef46fb296ab76aad"
   integrity sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==
 
-ramda@^0.27.1:
-  version "0.27.1"
-  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.27.1.tgz#66fc2df3ef873874ffc2da6aa8984658abacf5c9"
-  integrity sha512-PgIdVpn5y5Yns8vqb8FzBUEYn98V3xcPgawAkkgj0YJ0qDsnHCiNmZYfOGMgOvoB0eWFLpYbhxUR3mxfDIMvpw==
+rambda@^7.1.0:
+  version "7.2.1"
+  resolved "https://registry.yarnpkg.com/rambda/-/rambda-7.2.1.tgz#c533f6e2def4edcd59f967df938ace5dd6da56af"
+  integrity sha512-Wswj8ZvzdI3VhaGPkZAxaCTwuMmGtgWt7Zxsgyo4P+iTmVnkojvyWaOep5q3ZjMIecW0wtQa66GWxaKkZ24RAA==
 
 read-package-json-fast@^2.0.1:
   version "2.0.3"


### PR DESCRIPTION
The only breaking changes are dropping of support for older versions of Node.js, and adding `mocha/no-empty-description` to the recommended configuration.