### PR TITLE
Forbid TypeScript's private modifier in favour of hash names

### DIFF
--- a/packages/typescript/rules-snapshot.json
+++ b/packages/typescript/rules-snapshot.json
@@ -90,6 +90,13 @@
   "no-new-symbol": "off",
   "no-obj-calls": "off",
   "no-redeclare": "off",
+  "no-restricted-syntax": [
+    "error",
+    {
+      "selector": "PropertyDefinition[accessibility='private'], MethodDefinition[accessibility='private'], TSParameterProperty[accessibility='private']",
+      "message": "Use a hash name instead."
+    }
+  ],
   "no-setter-return": "off",
   "no-shadow": "off",
   "no-this-before-super": "off",

--- a/packages/typescript/src/index.js
+++ b/packages/typescript/src/index.js
@@ -95,5 +95,15 @@ module.exports = {
     'jsdoc/require-property-type': 'off',
     'jsdoc/require-returns-type': 'off',
     'jsdoc/valid-types': 'off',
+
+    // Prefer hash names over TypeScript's `private` modifier.
+    'no-restricted-syntax': [
+      'error',
+      {
+        selector:
+          "PropertyDefinition[accessibility='private'], MethodDefinition[accessibility='private'], TSParameterProperty[accessibility='private']",
+        message: 'Use a hash name instead.',
+      },
+    ],
   },
 };


### PR DESCRIPTION
`private` fields and methods in TypeScript are not truly private. They can still be accessed in runtime. Using hash names (e.g., `#name`) makes them truly private, enforced by JavaScript itself.