### PR TITLE
Automatically sort imports

### DIFF
--- a/packages/base/rules-snapshot.json
+++ b/packages/base/rules-snapshot.json
@@ -134,7 +134,20 @@
     }
   ],
   "import/no-webpack-loader-syntax": "error",
-  "import/order": "error",
+  "import/order": [
+    "error",
+    {
+      "newlines-between": "always",
+      "groups": [
+        ["builtin", "external"],
+        ["internal", "parent", "sibling", "index"]
+      ],
+      "alphabetize": {
+        "order": "asc",
+        "caseInsensitive": true
+      }
+    }
+  ],
   "import/unambiguous": "error",
   "indent": "off",
   "indent-legacy": "off",

--- a/packages/base/src/index.js
+++ b/packages/base/src/index.js
@@ -329,7 +329,30 @@ module.exports = {
       },
     ],
     'import/no-webpack-loader-syntax': 'error',
-    'import/order': 'error',
+    'import/order': [
+      'error',
+      {
+        // This means that there will always be a newline between the import
+        // groups as defined below.
+        'newlines-between': 'always',
+
+        groups: [
+          // "builtin" is Node.js modules that are built into the runtime, and
+          // "external" is everything else from node_modules.
+          ['builtin', 'external'],
+
+          // "internal" is unused, but could be used for absolute imports from
+          // the project root.
+          ['internal', 'parent', 'sibling', 'index'],
+        ],
+
+        // Alphabetically sort the imports within each group.
+        alphabetize: {
+          order: 'asc',
+          caseInsensitive: true,
+        },
+      },
+    ],
     'import/unambiguous': 'error',
 
     /* jsdoc plugin rules */

--- a/scripts/validate-configs.js
+++ b/scripts/validate-configs.js
@@ -1,5 +1,3 @@
-const { readdirSync, readFileSync, promises: fs } = require('fs');
-const pathUtils = require('path');
 const { FlatCompat } = require('@eslint/eslintrc');
 const { hasProperty } = require('@metamask/utils');
 const { recommendedConfig: eslintRecommendedConfig } = require('eslint');
@@ -7,6 +5,8 @@ const {
   configs: { recommended: prettierConfig },
 } = require('eslint-plugin-prettier');
 const deepEqual = require('fast-deep-equal');
+const { readdirSync, readFileSync, promises: fs } = require('fs');
+const pathUtils = require('path');
 const prettier = require('prettier');
 
 // For config parsing, validation, and rule flattening


### PR DESCRIPTION
I've added some configuration to the `import/order` rule, to make sure we automatically sort imports (fixable with `eslint --fix`). Imports will be sorted in two groups:

1. Node.js builtins and external modules (i.e., imports from `node_modules`).
2. Local (relative) imports.

Within these groups, imports are sorted alphabetically. A new line is placed between each import group, and the actual code.