### PR TITLE
Adapt package to latest module template standards

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,14 +1,9 @@
-# http://editorconfig.org
 root = true
 
 [*]
-charset = utf-8
-end_of_line = lf
-indent_size = 2
 indent_style = space
-insert_final_newline = true
+indent_size = 2
+end_of_line = lf
+charset = utf-8
 trim_trailing_whitespace = true
-
-[*.md]
-indent_size = 4
-trim_trailing_whitespace = false
+insert_final_newline = true

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -40,9 +40,3 @@ jobs:
           release-type: ${{ github.event.inputs.release-type }}
           release-version: ${{ github.event.inputs.release-version }}
           artifacts-path: gh-action__release-authors
-      # Upload the release author artifact for use in subsequent workflows
-      - uses: actions/upload-artifact@v3
-        with:
-          name: release-authors
-          path: gh-action__release-authors
-          if-no-files-found: error

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -21,7 +21,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           # This is to guarantee that the most recent tag is fetched.
           # This can be configured to a more reasonable value by consumers.
@@ -29,15 +29,20 @@ jobs:
           # We check out the specified branch, which will be used as the base
           # branch for all git operations and the release PR.
           ref: ${{ github.event.inputs.base-branch }}
-      - name: Get Node.js version
-        id: nvm
-        run: echo ::set-output name=NODE_VERSION::$(cat .nvmrc)
-      - uses: actions/setup-node@v2
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
         with:
-          node-version: ${{ steps.nvm.outputs.NODE_VERSION }}
+          node-version-file: '.nvmrc'
       - uses: MetaMask/action-create-release-pr@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           release-type: ${{ github.event.inputs.release-type }}
           release-version: ${{ github.event.inputs.release-version }}
+          artifacts-path: gh-action__release-authors
+      # Upload the release author artifact for use in subsequent workflows
+      - uses: actions/upload-artifact@v3
+        with:
+          name: release-authors
+          path: gh-action__release-authors
+          if-no-files-found: error

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -1,4 +1,4 @@
-name: Lint and Test
+name: Build, Lint, and Test
 
 on:
   push:
@@ -6,37 +6,42 @@ on:
   pull_request:
 
 jobs:
-  lint-test:
-    name: Lint and Test
-    runs-on: ubuntu-20.04
+  prepare:
+    name: Prepare
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'yarn'
+      - name: Install Yarn dependencies
+        run: yarn --immutable
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    needs:
+      - prepare
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [14.x, 16.x, 18.x, 19.x]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Get Yarn cache directory
-        run: echo "::set-output name=YARN_CACHE_DIR::$(yarn config get cacheFolder)"
-        id: yarn-cache-dir
-      - name: Get Yarn version
-        run: echo "::set-output name=YARN_VERSION::$(yarn --version)"
-        id: yarn-version
-      - name: Cache yarn dependencies
-        uses: actions/cache@v2
-        with:
-          path: ${{ steps.yarn-cache-dir.outputs.YARN_CACHE_DIR }}
-          key: yarn-cache-${{ runner.os }}-${{ steps.yarn-version.outputs.YARN_VERSION }}-${{ hashFiles('yarn.lock') }}
-      - run: yarn --immutable
-      - run: yarn lint # "Testing" (i.e. config validation) is also done here
+          cache: 'yarn'
+      - run: yarn --immutable --immutable-cache
+      - run: yarn lint
       - name: Validate RC changelog
-        if: ${{ startsWith(github.ref, 'release/') }}
-        run: yarn workspaces foreach --exclude root run auto-changelog validate --rc
+        if: ${{ startsWith(github.head_ref, 'release/') }}
+        run: yarn auto-changelog validate --rc
       - name: Validate changelog
-        if: ${{ !startsWith(github.ref, 'release/') }}
-        run: yarn workspaces foreach --exclude root run auto-changelog validate
+        if: ${{ !startsWith(github.head_ref, 'release/') }}
+        run: yarn auto-changelog validate
       - name: Require clean working directory
         shell: bash
         run: |
@@ -44,10 +49,45 @@ jobs:
             echo "Working tree dirty at end of job"
             exit 1
           fi
+
+  check-workflows:
+    name: Check workflows
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Download actionlint
+        id: download-actionlint
+        run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/7fdc9630cc360ea1a469eed64ac6d78caeda1234/scripts/download-actionlint.bash) 1.6.22
+        shell: bash
+      - name: Check workflow files
+        run: ${{ steps.download-actionlint.outputs.executable }} -color
+        shell: bash
+
   all-jobs-pass:
     name: All jobs pass
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs:
-      - lint-test
+      - lint
+      - check-workflows
     steps:
       - run: echo "Great success!"
+
+  is-release:
+    # release merge commits come from github-actions
+    if: startsWith(github.event.commits[0].author.name, 'github-actions')
+    needs:
+      - all-jobs-pass
+    outputs:
+      IS_RELEASE: ${{ steps.is-release.outputs.IS_RELEASE }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: MetaMask/action-is-release@v1
+        id: is-release
+
+  publish-release:
+    needs: is-release
+    if: needs.is-release.outputs.IS_RELEASE == 'true'
+    name: Publish release
+    permissions:
+      contents: write
+    uses: ./.github/workflows/publish-release.yml

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -38,10 +38,10 @@ jobs:
       - run: yarn lint
       - name: Validate RC changelog
         if: ${{ startsWith(github.head_ref, 'release/') }}
-        run: yarn auto-changelog validate --rc
+        run: yarn lint:changelogs --rc
       - name: Validate changelog
         if: ${{ !startsWith(github.head_ref, 'release/') }}
-        run: yarn auto-changelog validate
+        run: yarn lint:changelogs
       - name: Require clean working directory
         shell: bash
         run: |

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -1,4 +1,4 @@
-name: Build, Lint, and Test
+name: Lint and Test
 
 on:
   push:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -25,7 +25,6 @@ jobs:
         id: restore-build
         with:
           path: |
-            ./packages/*/src
             ./node_modules/.yarn-state.yml
           key: ${{ github.sha }}
 
@@ -40,7 +39,6 @@ jobs:
         id: restore-build
         with:
           path: |
-            ./packages/*/src
             ./node_modules/.yarn-state.yml
           key: ${{ github.sha }}
       - name: Dry Run Publish
@@ -61,7 +59,6 @@ jobs:
         id: restore-build
         with:
           path: |
-            ./packages/*/src
             ./node_modules/.yarn-state.yml
           key: ${{ github.sha }}
       - name: Publish

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,29 +1,74 @@
 name: Publish Release
 
 on:
-  pull_request:
-    types: [closed]
+  workflow_call:
 
 jobs:
   publish-release:
     permissions:
       contents: write
-    if: |
-      github.event.pull_request.merged == true &&
-      startsWith(github.event.pull_request.head.ref, 'release/')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
-          # We check out the release pull request's base branch, which will be
-          # used as the base branch for all git operations.
-          ref: ${{ github.event.pull_request.base.ref }}
-      - name: Get Node.js version
-        id: nvm
-        run: echo ::set-output name=NODE_VERSION::$(cat .nvmrc)
-      - uses: actions/setup-node@v2
+          ref: ${{ github.sha }}
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
         with:
-          node-version: ${{ steps.nvm.outputs.NODE_VERSION }}
-      - uses: MetaMask/action-publish-release@v1
+          node-version-file: '.nvmrc'
+      - uses: MetaMask/action-publish-release@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install
+        run: yarn install
+      - uses: actions/cache@v3
+        id: restore-build
+        with:
+          path: |
+            ./packages/*/src
+            ./node_modules/.yarn-state.yml
+          key: ${{ github.sha }}
+
+  publish-npm-dry-run:
+    runs-on: ubuntu-latest
+    needs: publish-release
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.sha }}
+      - uses: actions/cache@v3
+        id: restore-build
+        with:
+          path: |
+            ./packages/*/src
+            ./node_modules/.yarn-state.yml
+          key: ${{ github.sha }}
+      - name: Dry Run Publish
+        # omit npm-token token to perform dry run publish
+        uses: MetaMask/action-npm-publish@v2
+        env:
+          SKIP_PREPACK: true
+
+  publish-npm:
+    environment: npm-publish
+    runs-on: ubuntu-latest
+    needs: publish-npm-dry-run
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.sha }}
+      - uses: actions/cache@v3
+        id: restore-build
+        with:
+          path: |
+            ./packages/*/src
+            ./node_modules/.yarn-state.yml
+          key: ${{ github.sha }}
+      - name: Publish
+        uses: MetaMask/action-npm-publish@v2
+        with:
+          # This `NPM_TOKEN` needs to be manually set per-repository.
+          # Look in the repository settings under "Environments", and set this token in the `npm-publish` environment.
+          npm-token: ${{ secrets.NPM_TOKEN }}
+        env:
+          SKIP_PREPACK: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,7 @@
-*.lerna_backup
-*.har
+.DS_Store
 dist/
-build-artifacts/
-./packages/**/yarn.lock
+coverage/
+docs/
 
 # Logs
 logs

--- a/README.md
+++ b/README.md
@@ -4,7 +4,20 @@ This monorepo contains MetaMask's ESLint configurations as npm packages.
 The different configs are split up into individual packages so that we can
 correctly specify their peer dependencies.
 
-## Updating or Adding Configs
+## Contributing
+
+### Setup
+
+- Install [Node.js](https://nodejs.org) version 14
+  - If you are using [nvm](https://github.com/creationix/nvm#installation) (recommended) running `nvm use` will automatically choose the right node version for you.
+- Install [Yarn v3](https://yarnpkg.com/getting-started/install)
+- Run `yarn install` to install dependencies and run any required post-install scripts
+
+### Testing and Linting
+
+Run `yarn lint` to run the linter, or run `yarn lint:fix` to run the linter and fix any automatically fixable issues.
+
+### Updating or Adding Configs
 
 Configs targeting an entirely new environment should be added in a new package.
 Our rule validation script (see `./scripts/validate-rules.js`) forbids the
@@ -26,3 +39,41 @@ extended configs, each package has a `rules-snapshot.json` fill which contains
 all rules of the particular config and its extended configs in a single
 dictionary. When editing a package, always check its rules snapshots after
 running `yarn lint:fix` to understand which rules changed.
+
+### Release & Publishing
+
+The project follows the same release process as the other libraries in the MetaMask organization. The GitHub Actions [`action-create-release-pr`](https://github.com/MetaMask/action-create-release-pr) and [`action-publish-release`](https://github.com/MetaMask/action-publish-release) are used to automate the release process; see those repositories for more information about how they work.
+
+1. Choose a release version.
+
+  - The release version should be chosen according to SemVer. Analyze the changes to see whether they include any breaking changes, new features, or deprecations, then choose the appropriate SemVer version. See [the SemVer specification](https://semver.org/) for more information.
+
+2. If this release is backporting changes onto a previous release, then ensure there is a major version branch for that version (e.g. `1.x` for a `v1` backport release).
+
+  - The major version branch should be set to the most recent release with that major version. For example, when backporting a `v1.0.2` release, you'd want to ensure there was a `1.x` branch that was set to the `v1.0.1` tag.
+
+3. Trigger the [`workflow_dispatch`](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#workflow_dispatch) event [manually](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow) for the `Create Release Pull Request` action to create the release PR.
+
+  - For a backport release, the base branch should be the major version branch that you ensured existed in step 2. For a normal release, the base branch should be the main branch for that repository (which should be the default value).
+  - This should trigger the [`action-create-release-pr`](https://github.com/MetaMask/action-create-release-pr) workflow to create the release PR.
+
+4. Update the changelog to move each change entry into the appropriate change category ([See here](https://keepachangelog.com/en/1.0.0/#types) for the full list of change categories, and the correct ordering), and edit them to be more easily understood by users of the package.
+
+  - Generally any changes that don't affect consumers of the package (e.g. lockfile changes or development environment changes) are omitted. Exceptions may be made for changes that might be of interest despite not having an effect upon the published package (e.g. major test improvements, security improvements, improved documentation, etc.).
+  - Try to explain each change in terms that users of the package would understand (e.g. avoid referencing internal variables/concepts).
+  - Consolidate related changes into one change entry if it makes it easier to explain.
+  - Run `yarn auto-changelog validate --rc` to check that the changelog is correctly formatted.
+
+5. Review and QA the release.
+
+  - If changes are made to the base branch, the release branch will need to be updated with these changes and review/QA will need to restart again. As such, it's probably best to avoid merging other PRs into the base branch while review is underway.
+
+6. Squash & Merge the release.
+
+  - This should trigger the [`action-publish-release`](https://github.com/MetaMask/action-publish-release) workflow to tag the final release commit and publish the release on GitHub.
+
+7. Publish the release on npm.
+
+  - Wait for the `publish-release` GitHub Action workflow to finish. This should trigger a second job (`publish-npm`), which will wait for a run approval by the [`npm publishers`](https://github.com/orgs/MetaMask/teams/npm-publishers) team.
+  - Approve the `publish-npm` job (or ask somebody on the npm publishers team to approve it for you).
+  - Once the `publish-npm` job has finished, check npm to verify that it has been published.

--- a/README.md
+++ b/README.md
@@ -46,34 +46,34 @@ The project follows the same release process as the other libraries in the MetaM
 
 1. Choose a release version.
 
-  - The release version should be chosen according to SemVer. Analyze the changes to see whether they include any breaking changes, new features, or deprecations, then choose the appropriate SemVer version. See [the SemVer specification](https://semver.org/) for more information.
+- The release version should be chosen according to SemVer. Analyze the changes to see whether they include any breaking changes, new features, or deprecations, then choose the appropriate SemVer version. See [the SemVer specification](https://semver.org/) for more information.
 
 2. If this release is backporting changes onto a previous release, then ensure there is a major version branch for that version (e.g. `1.x` for a `v1` backport release).
 
-  - The major version branch should be set to the most recent release with that major version. For example, when backporting a `v1.0.2` release, you'd want to ensure there was a `1.x` branch that was set to the `v1.0.1` tag.
+- The major version branch should be set to the most recent release with that major version. For example, when backporting a `v1.0.2` release, you'd want to ensure there was a `1.x` branch that was set to the `v1.0.1` tag.
 
 3. Trigger the [`workflow_dispatch`](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#workflow_dispatch) event [manually](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow) for the `Create Release Pull Request` action to create the release PR.
 
-  - For a backport release, the base branch should be the major version branch that you ensured existed in step 2. For a normal release, the base branch should be the main branch for that repository (which should be the default value).
-  - This should trigger the [`action-create-release-pr`](https://github.com/MetaMask/action-create-release-pr) workflow to create the release PR.
+- For a backport release, the base branch should be the major version branch that you ensured existed in step 2. For a normal release, the base branch should be the main branch for that repository (which should be the default value).
+- This should trigger the [`action-create-release-pr`](https://github.com/MetaMask/action-create-release-pr) workflow to create the release PR.
 
 4. Update the changelog to move each change entry into the appropriate change category ([See here](https://keepachangelog.com/en/1.0.0/#types) for the full list of change categories, and the correct ordering), and edit them to be more easily understood by users of the package.
 
-  - Generally any changes that don't affect consumers of the package (e.g. lockfile changes or development environment changes) are omitted. Exceptions may be made for changes that might be of interest despite not having an effect upon the published package (e.g. major test improvements, security improvements, improved documentation, etc.).
-  - Try to explain each change in terms that users of the package would understand (e.g. avoid referencing internal variables/concepts).
-  - Consolidate related changes into one change entry if it makes it easier to explain.
-  - Run `yarn auto-changelog validate --rc` to check that the changelog is correctly formatted.
+- Generally any changes that don't affect consumers of the package (e.g. lockfile changes or development environment changes) are omitted. Exceptions may be made for changes that might be of interest despite not having an effect upon the published package (e.g. major test improvements, security improvements, improved documentation, etc.).
+- Try to explain each change in terms that users of the package would understand (e.g. avoid referencing internal variables/concepts).
+- Consolidate related changes into one change entry if it makes it easier to explain.
+- Run `yarn auto-changelog validate --rc` to check that the changelog is correctly formatted.
 
 5. Review and QA the release.
 
-  - If changes are made to the base branch, the release branch will need to be updated with these changes and review/QA will need to restart again. As such, it's probably best to avoid merging other PRs into the base branch while review is underway.
+- If changes are made to the base branch, the release branch will need to be updated with these changes and review/QA will need to restart again. As such, it's probably best to avoid merging other PRs into the base branch while review is underway.
 
 6. Squash & Merge the release.
 
-  - This should trigger the [`action-publish-release`](https://github.com/MetaMask/action-publish-release) workflow to tag the final release commit and publish the release on GitHub.
+- This should trigger the [`action-publish-release`](https://github.com/MetaMask/action-publish-release) workflow to tag the final release commit and publish the release on GitHub.
 
 7. Publish the release on npm.
 
-  - Wait for the `publish-release` GitHub Action workflow to finish. This should trigger a second job (`publish-npm`), which will wait for a run approval by the [`npm publishers`](https://github.com/orgs/MetaMask/teams/npm-publishers) team.
-  - Approve the `publish-npm` job (or ask somebody on the npm publishers team to approve it for you).
-  - Once the `publish-npm` job has finished, check npm to verify that it has been published.
+- Wait for the `publish-release` GitHub Action workflow to finish. This should trigger a second job (`publish-npm`), which will wait for a run approval by the [`npm publishers`](https://github.com/orgs/MetaMask/teams/npm-publishers) team.
+- Approve the `publish-npm` job (or ask somebody on the npm publishers team to approve it for you).
+- Once the `publish-npm` job has finished, check npm to verify that it has been published.

--- a/package.json
+++ b/package.json
@@ -2,19 +2,19 @@
   "name": "root",
   "version": "10.0.0",
   "private": true,
-  "engines": {
-    "node": ">=14.0.0"
-  },
-  "scripts": {
-    "lint:eslint": "yarn eslint . --ext ts,js",
-    "lint:config-validation": "node ./scripts/validate-configs.js",
-    "lint:misc": "prettier '**/*.json' '!**/rules-snapshot.json' '**/*.md' '!**/CHANGELOG.md' '**/*.yml' --ignore-path .gitignore",
-    "lint": "yarn lint:eslint && yarn lint:misc --check && yarn lint:config-validation",
-    "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write && yarn lint:config-validation --write"
-  },
   "workspaces": [
     "packages/*"
   ],
+  "scripts": {
+    "lint": "yarn lint:eslint && yarn lint:misc --check && yarn lint:config-validation",
+    "lint:config-validation": "node ./scripts/validate-configs.js",
+    "lint:eslint": "yarn eslint . --ext ts,js",
+    "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write && yarn lint:config-validation --write",
+    "lint:misc": "prettier '**/*.json' '!**/rules-snapshot.json' '**/*.md' '!**/CHANGELOG.md' '**/*.yml' --ignore-path .gitignore"
+  },
+  "resolutions": {
+    "eslint@^8.21.0": "patch:eslint@npm%3A8.21.0#./.yarn/patches/eslint-npm-8.21.0-b57f835038.patch"
+  },
   "devDependencies": {
     "@eslint/eslintrc": "^1.3.0",
     "@lavamoat/allow-scripts": "^2.0.3",
@@ -29,15 +29,16 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^4.2.1",
     "fast-deep-equal": "^3.1.3",
-    "prettier": "^2.2.1"
+    "prettier": "^2.7.1",
+    "prettier-plugin-packagejson": "^2.2.18"
+  },
+  "packageManager": "yarn@3.2.4",
+  "engines": {
+    "node": ">=14.0.0"
   },
   "lavamoat": {
     "allowScripts": {
       "@lavamoat/preinstall-always-fail": false
     }
-  },
-  "packageManager": "yarn@3.2.4",
-  "resolutions": {
-    "eslint@^8.21.0": "patch:eslint@npm%3A8.21.0#./.yarn/patches/eslint-npm-8.21.0-b57f835038.patch"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "root",
   "version": "10.0.0",
   "private": true,
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/MetaMask/eslint-config.git"
+  },
   "workspaces": [
     "packages/*"
   ],

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "lint:config-validation": "node ./scripts/validate-configs.js",
     "lint:eslint": "yarn eslint . --ext ts,js",
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write && yarn lint:config-validation --write",
-    "lint:misc": "prettier '**/*.json' '!**/rules-snapshot.json' '**/*.md' '!**/CHANGELOG.md' '**/*.yml' --ignore-path .gitignore"
+    "lint:misc": "prettier '**/*.json' '!**/rules-snapshot.json' '**/*.md' '!**/CHANGELOG.md' '**/*.yml' '!.yarnrc.yml' --ignore-path .gitignore"
   },
   "resolutions": {
     "eslint@^8.21.0": "patch:eslint@npm%3A8.21.0#./.yarn/patches/eslint-npm-8.21.0-b57f835038.patch"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "packages/*"
   ],
   "scripts": {
-    "lint": "yarn lint:eslint && yarn lint:misc --check && yarn lint:config-validation && yarn lint:changelogs",
+    "lint": "yarn lint:eslint && yarn lint:misc --check && yarn lint:config-validation",
     "lint:changelogs": "yarn workspaces foreach --parallel --verbose run lint:changelog",
     "lint:config-validation": "node ./scripts/validate-configs.js",
     "lint:eslint": "yarn eslint . --ext ts,js",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "packages/*"
   ],
   "scripts": {
-    "lint": "yarn lint:eslint && yarn lint:misc --check && yarn lint:config-validation",
+    "lint": "yarn lint:eslint && yarn lint:misc --check && yarn lint:config-validation && yarn lint:changelogs",
+    "lint:changelogs": "yarn workspaces foreach --parallel --verbose run lint:changelog",
     "lint:config-validation": "node ./scripts/validate-configs.js",
     "lint:eslint": "yarn eslint . --ext ts,js",
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write && yarn lint:config-validation --write",

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -16,10 +16,12 @@
     "src/"
   ],
   "scripts": {
+    "lint:changelog": "auto-changelog validate",
     "publish": "npm publish",
     "test": "eslint ."
   },
   "devDependencies": {
+    "@metamask/auto-changelog": "^3.0.0",
     "eslint": "^8.21.0",
     "eslint-config-prettier": "^8.1.0",
     "eslint-plugin-import": "^2.26.0",

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -2,30 +2,23 @@
   "name": "@metamask/eslint-config",
   "version": "10.0.0",
   "description": "Shareable MetaMask ESLint config.",
-  "main": "src/index.js",
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/",
-    "access": "public"
-  },
-  "files": [
-    "src/"
-  ],
-  "engines": {
-    "node": ">=14.0.0"
-  },
-  "scripts": {
-    "test": "eslint .",
-    "publish": "npm publish"
+  "homepage": "https://github.com/MetaMask/eslint-config#readme",
+  "bugs": {
+    "url": "https://github.com/MetaMask/eslint-config/issues"
   },
   "repository": {
     "type": "git",
     "url": "https://github.com/MetaMask/eslint-config.git"
   },
   "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/MetaMask/eslint-config/issues"
+  "main": "src/index.js",
+  "files": [
+    "src/"
+  ],
+  "scripts": {
+    "publish": "npm publish",
+    "test": "eslint ."
   },
-  "homepage": "https://github.com/MetaMask/eslint-config#readme",
   "devDependencies": {
     "eslint": "^8.21.0",
     "eslint-config-prettier": "^8.1.0",
@@ -41,5 +34,12 @@
     "eslint-plugin-jsdoc": "^39.2.9",
     "eslint-plugin-prettier": "^4.2.1",
     "prettier": "^2.2.1"
+  },
+  "engines": {
+    "node": ">=14.0.0"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -16,10 +16,12 @@
     "src/"
   ],
   "scripts": {
+    "lint:changelog": "auto-changelog validate",
     "publish": "npm publish",
     "test": "eslint ."
   },
   "devDependencies": {
+    "@metamask/auto-changelog": "^3.0.0",
     "@metamask/eslint-config": "^10.0.0",
     "eslint": "^8.21.0",
     "eslint-config-prettier": "^8.1.0",

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -2,30 +2,23 @@
   "name": "@metamask/eslint-config-jest",
   "version": "10.0.0",
   "description": "Shareable MetaMask ESLint config for Jest.",
-  "main": "src/index.js",
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/",
-    "access": "public"
-  },
-  "files": [
-    "src/"
-  ],
-  "engines": {
-    "node": ">=14.0.0"
-  },
-  "scripts": {
-    "test": "eslint .",
-    "publish": "npm publish"
+  "homepage": "https://github.com/MetaMask/eslint-config#readme",
+  "bugs": {
+    "url": "https://github.com/MetaMask/eslint-config/issues"
   },
   "repository": {
     "type": "git",
     "url": "https://github.com/MetaMask/eslint-config.git"
   },
   "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/MetaMask/eslint-config/issues"
+  "main": "src/index.js",
+  "files": [
+    "src/"
+  ],
+  "scripts": {
+    "publish": "npm publish",
+    "test": "eslint ."
   },
-  "homepage": "https://github.com/MetaMask/eslint-config#readme",
   "devDependencies": {
     "@metamask/eslint-config": "^10.0.0",
     "eslint": "^8.21.0",
@@ -40,5 +33,12 @@
     "@metamask/eslint-config": "^10.0.0",
     "eslint": "^8.21.0",
     "eslint-plugin-jest": "^26.8.2"
+  },
+  "engines": {
+    "node": ">=14.0.0"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/mocha/package.json
+++ b/packages/mocha/package.json
@@ -16,10 +16,12 @@
     "src/"
   ],
   "scripts": {
+    "lint:changelog": "auto-changelog validate",
     "publish": "npm publish",
     "test": "eslint ."
   },
   "devDependencies": {
+    "@metamask/auto-changelog": "^3.0.0",
     "@metamask/eslint-config": "^10.0.0",
     "eslint": "^8.21.0",
     "eslint-config-prettier": "^8.1.0",

--- a/packages/mocha/package.json
+++ b/packages/mocha/package.json
@@ -2,30 +2,23 @@
   "name": "@metamask/eslint-config-mocha",
   "version": "10.0.0",
   "description": "Shareable MetaMask ESLint config for Mocha.",
-  "main": "src/index.js",
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/",
-    "access": "public"
-  },
-  "files": [
-    "src/"
-  ],
-  "engines": {
-    "node": ">=14.0.0"
-  },
-  "scripts": {
-    "test": "eslint .",
-    "publish": "npm publish"
+  "homepage": "https://github.com/MetaMask/eslint-config#readme",
+  "bugs": {
+    "url": "https://github.com/MetaMask/eslint-config/issues"
   },
   "repository": {
     "type": "git",
     "url": "https://github.com/MetaMask/eslint-config.git"
   },
   "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/MetaMask/eslint-config/issues"
+  "main": "src/index.js",
+  "files": [
+    "src/"
+  ],
+  "scripts": {
+    "publish": "npm publish",
+    "test": "eslint ."
   },
-  "homepage": "https://github.com/MetaMask/eslint-config#readme",
   "devDependencies": {
     "@metamask/eslint-config": "^10.0.0",
     "eslint": "^8.21.0",
@@ -40,5 +33,12 @@
     "@metamask/eslint-config": "^10.0.0",
     "eslint": "^8.21.0",
     "eslint-plugin-mocha": "^10.1.0"
+  },
+  "engines": {
+    "node": ">=14.0.0"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/nodejs/package.json
+++ b/packages/nodejs/package.json
@@ -16,10 +16,12 @@
     "src/"
   ],
   "scripts": {
+    "lint:changelog": "auto-changelog validate",
     "publish": "npm publish",
     "test": "eslint ."
   },
   "devDependencies": {
+    "@metamask/auto-changelog": "^3.0.0",
     "@metamask/eslint-config": "^10.0.0",
     "eslint": "^8.21.0",
     "eslint-config-prettier": "^8.1.0",

--- a/packages/nodejs/package.json
+++ b/packages/nodejs/package.json
@@ -2,30 +2,23 @@
   "name": "@metamask/eslint-config-nodejs",
   "version": "10.0.0",
   "description": "Shareable MetaMask ESLint config for Node.js.",
-  "main": "src/index.js",
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/",
-    "access": "public"
-  },
-  "files": [
-    "src/"
-  ],
-  "engines": {
-    "node": ">=14.0.0"
-  },
-  "scripts": {
-    "test": "eslint .",
-    "publish": "npm publish"
+  "homepage": "https://github.com/MetaMask/eslint-config#readme",
+  "bugs": {
+    "url": "https://github.com/MetaMask/eslint-config/issues"
   },
   "repository": {
     "type": "git",
     "url": "https://github.com/MetaMask/eslint-config.git"
   },
   "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/MetaMask/eslint-config/issues"
+  "main": "src/index.js",
+  "files": [
+    "src/"
+  ],
+  "scripts": {
+    "publish": "npm publish",
+    "test": "eslint ."
   },
-  "homepage": "https://github.com/MetaMask/eslint-config#readme",
   "devDependencies": {
     "@metamask/eslint-config": "^10.0.0",
     "eslint": "^8.21.0",
@@ -40,5 +33,12 @@
     "@metamask/eslint-config": "^10.0.0",
     "eslint": "^8.21.0",
     "eslint-plugin-node": "^11.1.0"
+  },
+  "engines": {
+    "node": ">=14.0.0"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -2,30 +2,23 @@
   "name": "@metamask/eslint-config-typescript",
   "version": "10.0.0",
   "description": "Shareable MetaMask ESLint config for TypeScript.",
-  "main": "src/index.js",
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/",
-    "access": "public"
-  },
-  "files": [
-    "src/"
-  ],
-  "engines": {
-    "node": ">=14.0.0"
-  },
-  "scripts": {
-    "test": "eslint .",
-    "publish": "npm publish"
+  "homepage": "https://github.com/MetaMask/eslint-config#readme",
+  "bugs": {
+    "url": "https://github.com/MetaMask/eslint-config/issues"
   },
   "repository": {
     "type": "git",
     "url": "https://github.com/MetaMask/eslint-config.git"
   },
   "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/MetaMask/eslint-config/issues"
+  "main": "src/index.js",
+  "files": [
+    "src/"
+  ],
+  "scripts": {
+    "publish": "npm publish",
+    "test": "eslint ."
   },
-  "homepage": "https://github.com/MetaMask/eslint-config#readme",
   "devDependencies": {
     "@metamask/eslint-config": "^10.0.0",
     "@typescript-eslint/eslint-plugin": "^5.33.0",
@@ -44,5 +37,12 @@
     "@typescript-eslint/parser": "^5.33.0",
     "eslint": "^8.21.0",
     "typescript": "^4.0.7"
+  },
+  "engines": {
+    "node": ">=14.0.0"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -16,10 +16,12 @@
     "src/"
   ],
   "scripts": {
+    "lint:changelog": "auto-changelog validate",
     "publish": "npm publish",
     "test": "eslint ."
   },
   "devDependencies": {
+    "@metamask/auto-changelog": "^3.0.0",
     "@metamask/eslint-config": "^10.0.0",
     "@typescript-eslint/eslint-plugin": "^5.33.0",
     "@typescript-eslint/parser": "^5.33.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -100,6 +100,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@metamask/eslint-config-jest@workspace:packages/jest"
   dependencies:
+    "@metamask/auto-changelog": ^3.0.0
     "@metamask/eslint-config": ^10.0.0
     eslint: ^8.21.0
     eslint-config-prettier: ^8.1.0
@@ -119,6 +120,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@metamask/eslint-config-mocha@workspace:packages/mocha"
   dependencies:
+    "@metamask/auto-changelog": ^3.0.0
     "@metamask/eslint-config": ^10.0.0
     eslint: ^8.21.0
     eslint-config-prettier: ^8.1.0
@@ -138,6 +140,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@metamask/eslint-config-nodejs@workspace:packages/nodejs"
   dependencies:
+    "@metamask/auto-changelog": ^3.0.0
     "@metamask/eslint-config": ^10.0.0
     eslint: ^8.21.0
     eslint-config-prettier: ^8.1.0
@@ -157,6 +160,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@metamask/eslint-config-typescript@workspace:packages/typescript"
   dependencies:
+    "@metamask/auto-changelog": ^3.0.0
     "@metamask/eslint-config": ^10.0.0
     "@typescript-eslint/eslint-plugin": ^5.33.0
     "@typescript-eslint/parser": ^5.33.0
@@ -180,6 +184,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@metamask/eslint-config@workspace:packages/base"
   dependencies:
+    "@metamask/auto-changelog": ^3.0.0
     eslint: ^8.21.0
     eslint-config-prettier: ^8.1.0
     eslint-plugin-import: ^2.26.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -271,6 +271,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/glob@npm:^7.1.1":
+  version: 7.2.0
+  resolution: "@types/glob@npm:7.2.0"
+  dependencies:
+    "@types/minimatch": "*"
+    "@types/node": "*"
+  checksum: 6ae717fedfdfdad25f3d5a568323926c64f52ef35897bcac8aca8e19bc50c0bd84630bbd063e5d52078b2137d8e7d3c26eabebd1a2f03ff350fff8a91e79fc19
+  languageName: node
+  linkType: hard
+
 "@types/json-schema@npm:^7.0.9":
   version: 7.0.11
   resolution: "@types/json-schema@npm:7.0.11"
@@ -285,10 +295,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/minimatch@npm:*":
+  version: 5.1.2
+  resolution: "@types/minimatch@npm:5.1.2"
+  checksum: 0391a282860c7cb6fe262c12b99564732401bdaa5e395bee9ca323c312c1a0f45efbf34dce974682036e857db59a5c9b1da522f3d6055aeead7097264c8705a8
+  languageName: node
+  linkType: hard
+
 "@types/ms@npm:*":
   version: 0.7.31
   resolution: "@types/ms@npm:0.7.31"
   checksum: daadd354aedde024cce6f5aa873fefe7b71b22cd0e28632a69e8b677aeb48ae8caa1c60e5919bb781df040d116b01cb4316335167a3fc0ef6a63fa3614c0f6da
+  languageName: node
+  linkType: hard
+
+"@types/node@npm:*":
+  version: 18.11.9
+  resolution: "@types/node@npm:18.11.9"
+  checksum: cc0aae109e9b7adefc32eecb838d6fad931663bb06484b5e9cbbbf74865c721b03d16fd8d74ad90e31dbe093d956a7c2c306ba5429ba0c00f3f7505103d7a496
   languageName: node
   linkType: hard
 
@@ -803,6 +827,20 @@ __metadata:
   version: 1.0.0
   resolution: "delegates@npm:1.0.0"
   checksum: a51744d9b53c164ba9c0492471a1a2ffa0b6727451bdc89e31627fdf4adda9d51277cfcbfb20f0a6f08ccb3c436f341df3e92631a3440226d93a8971724771fd
+  languageName: node
+  linkType: hard
+
+"detect-indent@npm:^6.0.0":
+  version: 6.1.0
+  resolution: "detect-indent@npm:6.1.0"
+  checksum: ab953a73c72dbd4e8fc68e4ed4bfd92c97eb6c43734af3900add963fd3a9316f3bc0578b018b24198d4c31a358571eff5f0656e81a1f3b9ad5c547d58b2d093d
+  languageName: node
+  linkType: hard
+
+"detect-newline@npm:3.1.0":
+  version: 3.1.0
+  resolution: "detect-newline@npm:3.1.0"
+  checksum: ae6cd429c41ad01b164c59ea36f264a2c479598e61cba7c99da24175a7ab80ddf066420f2bec9a1c57a6bead411b4655ff15ad7d281c000a89791f48cbe939e7
   languageName: node
   linkType: hard
 
@@ -1335,6 +1373,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fast-glob@npm:^3.0.3":
+  version: 3.2.12
+  resolution: "fast-glob@npm:3.2.12"
+  dependencies:
+    "@nodelib/fs.stat": ^2.0.2
+    "@nodelib/fs.walk": ^1.2.3
+    glob-parent: ^5.1.2
+    merge2: ^1.3.0
+    micromatch: ^4.0.4
+  checksum: 0b1990f6ce831c7e28c4d505edcdaad8e27e88ab9fa65eedadb730438cfc7cde4910d6c975d6b7b8dc8a73da4773702ebcfcd6e3518e73938bb1383badfe01c2
+  languageName: node
+  linkType: hard
+
 "fast-glob@npm:^3.2.9":
   version: 3.2.11
   resolution: "fast-glob@npm:3.2.11"
@@ -1543,6 +1594,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"git-hooks-list@npm:1.0.3":
+  version: 1.0.3
+  resolution: "git-hooks-list@npm:1.0.3"
+  checksum: a1dd03d39c1d727ba08a35dbdbdcc6e96de8c4170c942dc95bf787ca6e34998d39fb5295a00242b58a3d265de0b69a0686d0cf583baa6b7830f268542c4576b9
+  languageName: node
+  linkType: hard
+
 "glob-parent@npm:^5.1.2":
   version: 5.1.2
   resolution: "glob-parent@npm:5.1.2"
@@ -1581,6 +1639,22 @@ __metadata:
   dependencies:
     type-fest: ^0.20.2
   checksum: fbaf4112e59b92c9f5575e85ce65e9e17c0b82711196ec5f58beb08599bbd92fd72703d6dfc9b080381fd35b644e1b11dcf25b38cc2341ec21df942594cbc8ce
+  languageName: node
+  linkType: hard
+
+"globby@npm:10.0.0":
+  version: 10.0.0
+  resolution: "globby@npm:10.0.0"
+  dependencies:
+    "@types/glob": ^7.1.1
+    array-union: ^2.1.0
+    dir-glob: ^3.0.1
+    fast-glob: ^3.0.3
+    glob: ^7.1.3
+    ignore: ^5.1.1
+    merge2: ^1.2.3
+    slash: ^3.0.0
+  checksum: fbff58d2fcaedd9207901f6e3b5341ff885b6d499c3a095f7befde0fd03ec1ea634452a82f81e894e46f6a5d704da44b842ba93066f90dced52adf84d4b8d1cc
   languageName: node
   linkType: hard
 
@@ -1889,6 +1963,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-plain-obj@npm:2.1.0":
+  version: 2.1.0
+  resolution: "is-plain-obj@npm:2.1.0"
+  checksum: cec9100678b0a9fe0248a81743041ed990c2d4c99f893d935545cfbc42876cbe86d207f3b895700c690ad2fa520e568c44afc1605044b535a7820c1d40e38daa
+  languageName: node
+  linkType: hard
+
 "is-regex@npm:^1.1.4":
   version: 1.1.4
   resolution: "is-regex@npm:1.1.4"
@@ -2111,7 +2192,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"merge2@npm:^1.3.0, merge2@npm:^1.4.1":
+"merge2@npm:^1.2.3, merge2@npm:^1.3.0, merge2@npm:^1.4.1":
   version: 1.4.1
   resolution: "merge2@npm:1.4.1"
   checksum: 7268db63ed5169466540b6fb947aec313200bcf6d40c5ab722c22e242f651994619bcd85601602972d3c85bd2cc45a358a4c61937e9f11a061919a1da569b0c2
@@ -2464,12 +2545,35 @@ __metadata:
   languageName: node
   linkType: hard
 
+"prettier-plugin-packagejson@npm:^2.2.18":
+  version: 2.3.0
+  resolution: "prettier-plugin-packagejson@npm:2.3.0"
+  dependencies:
+    sort-package-json: 1.57.0
+  peerDependencies:
+    prettier: ">= 1.16.0"
+  peerDependenciesMeta:
+    prettier:
+      optional: true
+  checksum: fbcf81cedcfd030440c106d502f121deb9acff2d50c2173ec202eccea66c7de03618eafe3d2a4011b73d76d7d41355edcb2fc11b3030e02a1f2ade91220f4a8a
+  languageName: node
+  linkType: hard
+
 "prettier@npm:^2.2.1":
   version: 2.2.1
   resolution: "prettier@npm:2.2.1"
   bin:
     prettier: bin-prettier.js
   checksum: 800de2df3d37067ab24478c7f32c60ca0c57b01742133287829feeb4a70d239a7bf6bccb56196784777af591ad80fb9ba70c1a49b0fcecf9f5622a764d513edb
+  languageName: node
+  linkType: hard
+
+"prettier@npm:^2.7.1":
+  version: 2.7.1
+  resolution: "prettier@npm:2.7.1"
+  bin:
+    prettier: bin-prettier.js
+  checksum: 55a4409182260866ab31284d929b3cb961e5fdb91fe0d2e099dac92eaecec890f36e524b4c19e6ceae839c99c6d7195817579cdffc8e2c80da0cb794463a748b
   languageName: node
   linkType: hard
 
@@ -2679,7 +2783,8 @@ __metadata:
     eslint-plugin-node: ^11.1.0
     eslint-plugin-prettier: ^4.2.1
     fast-deep-equal: ^3.1.3
-    prettier: ^2.2.1
+    prettier: ^2.7.1
+    prettier-plugin-packagejson: ^2.2.18
   languageName: unknown
   linkType: soft
 
@@ -2783,6 +2888,29 @@ __metadata:
   version: 3.0.0
   resolution: "slash@npm:3.0.0"
   checksum: 94a93fff615f25a999ad4b83c9d5e257a7280c90a32a7cb8b4a87996e4babf322e469c42b7f649fd5796edd8687652f3fb452a86dc97a816f01113183393f11c
+  languageName: node
+  linkType: hard
+
+"sort-object-keys@npm:^1.1.3":
+  version: 1.1.3
+  resolution: "sort-object-keys@npm:1.1.3"
+  checksum: abea944d6722a1710a1aa6e4f9509da085d93d5fc0db23947cb411eedc7731f80022ce8fa68ed83a53dd2ac7441fcf72a3f38c09b3d9bbc4ff80546aa2e151ad
+  languageName: node
+  linkType: hard
+
+"sort-package-json@npm:1.57.0":
+  version: 1.57.0
+  resolution: "sort-package-json@npm:1.57.0"
+  dependencies:
+    detect-indent: ^6.0.0
+    detect-newline: 3.1.0
+    git-hooks-list: 1.0.3
+    globby: 10.0.0
+    is-plain-obj: 2.1.0
+    sort-object-keys: ^1.1.3
+  bin:
+    sort-package-json: cli.js
+  checksum: 15758ba6b1033ae136863eabd4b8c8a28e79dd68b71327f6803c2ea740dc149dc9ad708b006d07ee9de56b6dc7cadb7c697801ad50c01348aa91022c6ff6e21d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
I've adapted this package to the latest module template standards. Due to the nature of this package, there are some differences between this and the module template:

- There are no build or test steps in the workflow, as we do not build anything and there are no tests.
- There is no documentation generation, as we do not have any JSDoc documentation.
- The publish workflow was adapted slightly to work without the need to build.

I've also updated `prettier` to the version used in the module template, and added `prettier-plugin-packagejson`.