### PR TITLE
Remove redundant `env` entry

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,10 +1,6 @@
 module.exports = {
   root: true,
 
-  env: {
-    node: true,
-  },
-
   parserOptions: {
     ecmaVersion: 2018,
   },


### PR DESCRIPTION
We don't need to set the environment to `node` in our ESLint config because that is set by the Node.js config, which we extend from.