### PR TITLE
Disable `import/no-nodejs-modules` in Node.js config

### DIFF
--- a/packages/nodejs/rules-snapshot.json
+++ b/packages/nodejs/rules-snapshot.json
@@ -1,4 +1,5 @@
 {
+  "import/no-nodejs-modules": "off",
   "no-process-exit": "off",
   "no-restricted-globals": [
     "error",

--- a/packages/nodejs/src/index.js
+++ b/packages/nodejs/src/index.js
@@ -55,5 +55,9 @@ module.exports = {
     // Deprecated eslint core rule, erroneously enabled by recommended Node rules
     // https://eslint.org/docs/rules/no-process-exit
     'no-process-exit': 'off',
+
+    // Enabled in the base config, but this should be allowed in Node.js
+    // projects.
+    'import/no-nodejs-modules': 'off',
   },
 };


### PR DESCRIPTION
`import/no-nodejs-modules` was enabled in the base config in #242, but incorrectly not disabled in the Node.js config. I've fixed that here.