### PR TITLE
Add `NPM_TOKEN` to publish-release workflow call

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -117,3 +117,5 @@ jobs:
     permissions:
       contents: write
     uses: ./.github/workflows/publish-release.yml
+    secrets:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -2,6 +2,9 @@ name: Publish Release
 
 on:
   workflow_call:
+    secrets:
+      NPM_TOKEN:
+        required: true
 
 jobs:
   publish-release:


### PR DESCRIPTION
Secrets in a workflow called through `workflow_call` require secrets to be defined explicitly: https://docs.github.com/en/actions/using-workflows/reusing-workflows#using-inputs-and-secrets-in-a-reusable-workflow