### PR TITLE
Allow async functions without any 'await'

### DIFF
--- a/packages/typescript/rules-snapshot.json
+++ b/packages/typescript/rules-snapshot.json
@@ -124,7 +124,7 @@
   "@typescript-eslint/prefer-reduce-type-parameter": "error",
   "@typescript-eslint/prefer-string-starts-ends-with": "error",
   "@typescript-eslint/promise-function-async": "error",
-  "@typescript-eslint/require-await": "error",
+  "@typescript-eslint/require-await": "off",
   "@typescript-eslint/restrict-plus-operands": "error",
   "@typescript-eslint/restrict-template-expressions": [
     "error",

--- a/packages/typescript/src/index.js
+++ b/packages/typescript/src/index.js
@@ -72,6 +72,9 @@ module.exports = {
     '@typescript-eslint/no-unsafe-member-access': 'off',
     '@typescript-eslint/no-unsafe-return': 'off',
 
+    // Recommended rules that we do not want to use
+    '@typescript-eslint/require-await': 'off',
+
     // Our rules that require type information
     '@typescript-eslint/consistent-type-exports': 'error',
     '@typescript-eslint/naming-convention': [


### PR DESCRIPTION
The lint rules have been updated to allow functions to be `async` even when they do not use `await`. It can be useful to make functions `async` sometimes even when `await` is not used, because it can simplify error handling for functions that return a Promise without `await`-ing it (it ensures errors are always rejected, not thrown). It can also be useful in cases when a function that does synchronous work needs to be async to match an interface.