### PR TITLE
Stop requiring newlines between multiline blocks/expressions

### DIFF
--- a/packages/base/rules-snapshot.json
+++ b/packages/base/rules-snapshot.json
@@ -3282,11 +3282,6 @@
       "blankLine": "any",
       "prev": "directive",
       "next": "directive"
-    },
-    {
-      "blankLine": "always",
-      "prev": ["multiline-block-like", "multiline-expression"],
-      "next": ["multiline-block-like", "multiline-expression"]
     }
   ],
   "prefer-arrow-callback": "off",

--- a/packages/base/src/index.js
+++ b/packages/base/src/index.js
@@ -241,11 +241,6 @@ module.exports = {
         prev: 'directive',
         next: 'directive',
       },
-      {
-        blankLine: 'always',
-        prev: ['multiline-block-like', 'multiline-expression'],
-        next: ['multiline-block-like', 'multiline-expression'],
-      },
     ],
     'prefer-const': 'error',
     'prefer-destructuring': [


### PR DESCRIPTION
This effectively reverts #197. This rule is being removed because we have found that it forces us to introduce newlines in places where they obstruct readability rather than helping it.

When grouping statements, it is often useful to "chunk" related lines together by using a newline before and after the chunk, to denote that each of the statements are related in some way. This is often done in unit tests for example, when the "arrange", "act", "assert" grouping style is used. This rule was forcing us to break up chunks.