### PR TITLE
Allow parameters to use PascalCase

### DIFF
--- a/packages/typescript/rules-snapshot.json
+++ b/packages/typescript/rules-snapshot.json
@@ -44,6 +44,11 @@
       "selector": "variable",
       "format": ["camelCase", "UPPER_CASE", "PascalCase"],
       "leadingUnderscore": "allow"
+    },
+    {
+      "selector": "parameter",
+      "format": ["camelCase", "PascalCase"],
+      "leadingUnderscore": "allow"
     }
   ],
   "@typescript-eslint/no-array-constructor": "error",

--- a/packages/typescript/src/index.js
+++ b/packages/typescript/src/index.js
@@ -111,6 +111,11 @@ module.exports = {
         format: ['camelCase', 'UPPER_CASE', 'PascalCase'],
         leadingUnderscore: 'allow',
       },
+      {
+        selector: 'parameter',
+        format: ['camelCase', 'PascalCase'],
+        leadingUnderscore: 'allow',
+      },
     ],
     '@typescript-eslint/no-meaningless-void-operator': 'error',
     '@typescript-eslint/no-unnecessary-boolean-literal-compare': 'error',


### PR DESCRIPTION
Parameters can now use PascaleCase. This can be useful in cases where a class constructor is being passed as a parameter.