### PR TITLE
Add rule `@typescript-eslint/prefer-enum-initializers`

### DIFF
--- a/packages/typescript/rules-snapshot.json
+++ b/packages/typescript/rules-snapshot.json
@@ -119,6 +119,7 @@
   "@typescript-eslint/no-useless-constructor": "error",
   "@typescript-eslint/no-var-requires": "error",
   "@typescript-eslint/prefer-as-const": "error",
+  "@typescript-eslint/prefer-enum-initializers": "error",
   "@typescript-eslint/prefer-for-of": "error",
   "@typescript-eslint/prefer-function-type": "error",
   "@typescript-eslint/prefer-includes": "error",

--- a/packages/typescript/src/index.js
+++ b/packages/typescript/src/index.js
@@ -124,6 +124,7 @@ module.exports = {
     '@typescript-eslint/no-unnecessary-boolean-literal-compare': 'error',
     '@typescript-eslint/no-unnecessary-qualifier': 'error',
     '@typescript-eslint/no-unnecessary-type-arguments': 'error',
+    '@typescript-eslint/prefer-enum-initializers': 'error',
     '@typescript-eslint/prefer-includes': 'error',
     '@typescript-eslint/prefer-nullish-coalescing': 'error',
     '@typescript-eslint/prefer-readonly': 'error',


### PR DESCRIPTION
The rule `@typescript-eslint/prefer-enum-initializers` has been added. This rule ensures that we use initializers for enums.

Uninitialized enums are hazardous because they implicitly assign each entry a sequential number value. This means that adding a new entry to the enum changes the value of every following entry. This can be confusing and unexpected, especially if this enum is stored in persisted state and now has a different meaning than before. Initialized enums, on the other hand, never unexpectedly change values.

This is a breaking change.