### PR TITLE
Enable `@typescript-eslint/consistent-type-imports` rule

### DIFF
--- a/packages/typescript/rules-snapshot.json
+++ b/packages/typescript/rules-snapshot.json
@@ -7,6 +7,7 @@
   "@typescript-eslint/consistent-type-assertions": "error",
   "@typescript-eslint/consistent-type-definitions": ["error", "type"],
   "@typescript-eslint/consistent-type-exports": "error",
+  "@typescript-eslint/consistent-type-imports": "error",
   "@typescript-eslint/default-param-last": "error",
   "@typescript-eslint/naming-convention": [
     "error",

--- a/packages/typescript/src/index.js
+++ b/packages/typescript/src/index.js
@@ -42,6 +42,7 @@ module.exports = {
     '@typescript-eslint/array-type': 'error',
     '@typescript-eslint/consistent-type-assertions': 'error',
     '@typescript-eslint/consistent-type-definitions': ['error', 'type'],
+    '@typescript-eslint/consistent-type-imports': 'error',
     '@typescript-eslint/no-explicit-any': 'off',
     '@typescript-eslint/no-namespace': [
       'error',


### PR DESCRIPTION
## Description

This pull request enables the `@typescript-eslint/consistent-type-imports` rule which helps to enforce the consistency
of writing type import statements across the codebase.

Without this rule, the following is allowed:

```ts
import { foo, bar, BazType } from 'package';
```

With this rule, it will automatically (upon running `eslint --fix`) turned into:

```ts
import type { BazType } from 'package';
import { foo, bar } from 'package';
```

## Changes

1. Enable the `@typescript-eslint/consistent-type-imports` rule.