### PR TITLE
Add `req`, `res`, `tx` to the `id-denylist`

### DIFF
--- a/packages/base/rules-snapshot.json
+++ b/packages/base/rules-snapshot.json
@@ -85,7 +85,10 @@
     "msg",
     "num",
     "opt",
-    "sig"
+    "sig",
+    "req",
+    "res",
+    "tx"
   ],
   "id-length": [
     "error",

--- a/packages/base/src/index.js
+++ b/packages/base/src/index.js
@@ -87,6 +87,9 @@ module.exports = {
       'num',
       'opt',
       'sig',
+      'req',
+      'res',
+      'tx',
     ],
     'id-length': [
       'error',


### PR DESCRIPTION
## Description

This pull request adds `req`, `res`, `tx` to the `id-denylist`. This ensures we use consistent variable naming across repositories. These names are commonly used in some older projects, but should be written out in full for better readability, in my opinion.

## Changes

1. Add `req` to the `id-denylist`.
2. Add `res` to the `id-denylist`.
3. Add `tx` to the `id-denylist`.