### PR TITLE
Add `eslint-plugin-promise` and enable `no-multiple-resolved`

### DIFF
--- a/packages/base/README.md
+++ b/packages/base/README.md
@@ -14,6 +14,7 @@ yarn add --dev \
     eslint-plugin-import@^2.26.0 \
     eslint-plugin-jsdoc@^39.6.2 \
     eslint-plugin-prettier@^4.2.1 \
+    eslint-plugin-promise@^6.1.1 \
     prettier@^2.7.1
 ```
 

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -28,6 +28,7 @@
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-jsdoc": "^39.6.2",
     "eslint-plugin-prettier": "^4.2.1",
+    "eslint-plugin-promise": "^6.1.1",
     "prettier": "^2.7.1"
   },
   "peerDependencies": {
@@ -36,6 +37,7 @@
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-jsdoc": "^39.6.2",
     "eslint-plugin-prettier": "^4.2.1",
+    "eslint-plugin-promise": "^6.1.1",
     "prettier": "^2.7.1"
   },
   "engines": {

--- a/packages/base/rules-snapshot.json
+++ b/packages/base/rules-snapshot.json
@@ -3320,6 +3320,7 @@
       "usePrettierrc": true
     }
   ],
+  "promise/no-multiple-resolved": "error",
   "quote-props": "off",
   "quotes": "off",
   "radix": "error",

--- a/packages/base/src/index.js
+++ b/packages/base/src/index.js
@@ -20,7 +20,7 @@ module.exports = {
     sourceType: 'script',
   },
 
-  plugins: ['jsdoc', 'prettier'],
+  plugins: ['jsdoc', 'prettier', 'promise'],
 
   extends: [
     'eslint:recommended',
@@ -394,5 +394,7 @@ module.exports = {
     'jsdoc/require-yields-check': 'error',
     'jsdoc/tag-lines': 'error',
     'jsdoc/valid-types': 'error',
+
+    'promise/no-multiple-resolved': 'error',
   },
 };

--- a/packages/browser/README.md
+++ b/packages/browser/README.md
@@ -15,6 +15,7 @@ yarn add --dev \
     eslint-plugin-import@^2.26.0 \
     eslint-plugin-jsdoc@^39.6.2 \
     eslint-plugin-prettier@^4.2.1 \
+    eslint-plugin-promise@^6.1.1 \
     prettier@^2.7.1
 ```
 

--- a/packages/commonjs/README.md
+++ b/packages/commonjs/README.md
@@ -13,6 +13,7 @@ yarn add --dev \
     eslint-plugin-import@^2.26.0 \
     eslint-plugin-jsdoc@^39.6.2 \
     eslint-plugin-prettier@^4.2.1 \
+    eslint-plugin-promise@^6.1.1 \
     prettier@^2.7.1
 ```
 

--- a/packages/jest/README.md
+++ b/packages/jest/README.md
@@ -14,6 +14,7 @@ yarn add --dev \
     eslint-plugin-jsdoc@^39.6.2 \
     eslint-plugin-jest@^27.1.5 \
     eslint-plugin-prettier@^4.2.1 \
+    eslint-plugin-promise@^6.1.1 \
     prettier@^2.7.1
 ```
 

--- a/packages/mocha/README.md
+++ b/packages/mocha/README.md
@@ -14,6 +14,7 @@ yarn add --dev \
     eslint-plugin-jsdoc@^39.6.2 \
     eslint-plugin-mocha@^10.1.0 \
     eslint-plugin-prettier@^4.2.1 \
+    eslint-plugin-promise@^6.1.1 \
     prettier@^2.7.1
 ```
 

--- a/packages/nodejs/README.md
+++ b/packages/nodejs/README.md
@@ -14,6 +14,7 @@ yarn add --dev \
     eslint-plugin-jsdoc@^39.6.2 \
     eslint-plugin-node@^11.1.0 \
     eslint-plugin-prettier@^4.2.1 \
+    eslint-plugin-promise@^6.1.1 \
     prettier@^2.7.1
 ```
 

--- a/packages/typescript/README.md
+++ b/packages/typescript/README.md
@@ -15,6 +15,7 @@ yarn add --dev \
     eslint-plugin-import@^2.26.0 \
     eslint-plugin-jsdoc@^39.6.2 \
     eslint-plugin-prettier@^4.2.1 \
+    eslint-plugin-promise@^6.1.1 \
     prettier@^2.7.1
 ```
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1033,6 +1033,7 @@ __metadata:
     eslint-plugin-import: ^2.26.0
     eslint-plugin-jsdoc: ^39.6.2
     eslint-plugin-prettier: ^4.2.1
+    eslint-plugin-promise: ^6.1.1
     prettier: ^2.7.1
   peerDependencies:
     eslint: ^8.27.0
@@ -1040,6 +1041,7 @@ __metadata:
     eslint-plugin-import: ^2.26.0
     eslint-plugin-jsdoc: ^39.6.2
     eslint-plugin-prettier: ^4.2.1
+    eslint-plugin-promise: ^6.1.1
     prettier: ^2.7.1
   languageName: unknown
   linkType: soft
@@ -2714,6 +2716,15 @@ __metadata:
     eslint-config-prettier:
       optional: true
   checksum: b9e839d2334ad8ec7a5589c5cb0f219bded260839a857d7a486997f9870e95106aa59b8756ff3f37202085ebab658de382b0267cae44c3a7f0eb0bcc03a4f6d6
+  languageName: node
+  linkType: hard
+
+"eslint-plugin-promise@npm:^6.1.1":
+  version: 6.1.1
+  resolution: "eslint-plugin-promise@npm:6.1.1"
+  peerDependencies:
+    eslint: ^7.0.0 || ^8.0.0
+  checksum: 46b9a4f79dae5539987922afc27cc17cbccdecf4f0ba19c0ccbf911b0e31853e9f39d9959eefb9637461b52772afa1a482f1f87ff16c1ba38bdb6fcf21897e9a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

This pull request adds the `eslint-plugin-promise` package as a dependency to our project and adds the `no-multiple-resolved` rule to ESLint configuration with this plugin enabled. This avoids the error-prone situation where both `resolve()` and `reject()` can be called.

## Changes

1. Add `eslint-plugin-promise` to the base package dependencies.
2. Add `no-multiple-resolved` rule to the ESLint configuration.
3. Update `rules-snapshot.json` to include the new rule.