### PR TITLE
jsdoc: remove deprecated rule jsdoc/newline-after-description

### DIFF
--- a/packages/base/rules-snapshot.json
+++ b/packages/base/rules-snapshot.json
@@ -173,7 +173,6 @@
     }
   ],
   "jsdoc/multiline-blocks": "error",
-  "jsdoc/newline-after-description": "error",
   "jsdoc/no-bad-blocks": "error",
   "jsdoc/no-defaults": "error",
   "jsdoc/no-multi-asterisks": "error",

--- a/packages/base/src/index.js
+++ b/packages/base/src/index.js
@@ -366,7 +366,6 @@ module.exports = {
       { tags: { param: true, returns: true } },
     ],
     'jsdoc/multiline-blocks': 'error',
-    'jsdoc/newline-after-description': 'error',
     'jsdoc/no-bad-blocks': 'error',
     'jsdoc/no-defaults': 'error',
     'jsdoc/no-multi-asterisks': 'error',


### PR DESCRIPTION
Will be causing error starting with eslint-plugin-jsdoc@43

https://github.com/gajus/eslint-plugin-jsdoc/issues/1031