### PR TITLE
Enforce generic parameter length of at least 3 characters

### DIFF
--- a/packages/typescript/rules-snapshot.json
+++ b/packages/typescript/rules-snapshot.json
@@ -42,6 +42,14 @@
       "format": ["PascalCase"]
     },
     {
+      "selector": "typeParameter",
+      "format": ["PascalCase"],
+      "custom": {
+        "regex": "^.{3,}",
+        "match": true
+      }
+    },
+    {
       "selector": "variable",
       "format": ["camelCase", "UPPER_CASE", "PascalCase"],
       "leadingUnderscore": "allow"

--- a/packages/typescript/src/index.js
+++ b/packages/typescript/src/index.js
@@ -111,6 +111,14 @@ module.exports = {
         format: ['PascalCase'],
       },
       {
+        selector: 'typeParameter',
+        format: ['PascalCase'],
+        custom: {
+          regex: '^.{3,}',
+          match: true,
+        },
+      },
+      {
         selector: 'variable',
         format: ['camelCase', 'UPPER_CASE', 'PascalCase'],
         leadingUnderscore: 'allow',


### PR DESCRIPTION
## Description

This pull request adds a new rule that enforces all generic parameters to have a length of at least 3 characters.

Before this change, this is allowed:

```ts
type Foo<T> = T;
``` 

After this change, you can do something like this instead:

```ts
type Foo<Type> = Type;
```

## Changes

1. Add a new rule to enforce the minimum length of generic parameters at 3 characters.