### PR TITLE
Revert "11.2.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "11.2.0",
+  "version": "11.1.0",
   "private": true,
   "repository": {
     "type": "git",

--- a/packages/base/CHANGELOG.md
+++ b/packages/base/CHANGELOG.md
@@ -6,10 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [11.2.0]
-### Added
-- Add `eslint-plugin-promise` and enable `no-multiple-resolved` ([#287](https://github.com/MetaMask/eslint-config/pull/287))
-
 ## [11.1.0]
 ### Changed
 - Exclude test files from package ([#266](https://github.com/MetaMask/eslint-config/pull/266))
@@ -164,8 +160,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add base, TypeScript, and Jest configs (#3)
 
-[Unreleased]: https://github.com/MetaMask/eslint-config/compare/v11.2.0...HEAD
-[11.2.0]: https://github.com/MetaMask/eslint-config/compare/v11.1.0...v11.2.0
+[Unreleased]: https://github.com/MetaMask/eslint-config/compare/v11.1.0...HEAD
 [11.1.0]: https://github.com/MetaMask/eslint-config/compare/v11.0.2...v11.1.0
 [11.0.2]: https://github.com/MetaMask/eslint-config/compare/v11.0.1...v11.0.2
 [11.0.1]: https://github.com/MetaMask/eslint-config/compare/v11.0.0...v11.0.1

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/eslint-config",
-  "version": "11.2.0",
+  "version": "11.1.0",
   "description": "Shareable MetaMask ESLint config.",
   "homepage": "https://github.com/MetaMask/eslint-config#readme",
   "bugs": {

--- a/packages/browser/CHANGELOG.md
+++ b/packages/browser/CHANGELOG.md
@@ -6,10 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [11.2.0]
-### Added
-- Add `eslint-plugin-promise` and enable `no-multiple-resolved` ([#287](https://github.com/MetaMask/eslint-config/pull/287))
-
 ## [11.1.0]
 ### Changed
 - Exclude test files from package ([#266](https://github.com/MetaMask/eslint-config/pull/266))
@@ -18,7 +14,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release of this package.
 
-[Unreleased]: https://github.com/MetaMask/eslint-config/compare/v11.2.0...HEAD
-[11.2.0]: https://github.com/MetaMask/eslint-config/compare/v11.1.0...v11.2.0
+[Unreleased]: https://github.com/MetaMask/eslint-config/compare/v11.1.0...HEAD
 [11.1.0]: https://github.com/MetaMask/eslint-config/compare/v11.0.0...v11.1.0
 [11.0.0]: https://github.com/MetaMask/eslint-config/releases/tag/v11.0.0

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/eslint-config-browser",
-  "version": "11.2.0",
+  "version": "11.1.0",
   "description": "Shareable MetaMask ESLint plugin for browser environments.",
   "homepage": "https://github.com/MetaMask/eslint-config#readme",
   "bugs": {

--- a/packages/commonjs/CHANGELOG.md
+++ b/packages/commonjs/CHANGELOG.md
@@ -6,14 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [11.2.0]
-### Added
-- Add `eslint-plugin-promise` and enable `no-multiple-resolved` ([#287](https://github.com/MetaMask/eslint-config/pull/287))
-
 ## [11.1.0]
 ### Added
 - Initial release of this package ([#267](https://github.com/MetaMask/eslint-config/pull/267))
 
-[Unreleased]: https://github.com/MetaMask/eslint-config/compare/v11.2.0...HEAD
-[11.2.0]: https://github.com/MetaMask/eslint-config/compare/v11.1.0...v11.2.0
+[Unreleased]: https://github.com/MetaMask/eslint-config/compare/v11.1.0...HEAD
 [11.1.0]: https://github.com/MetaMask/eslint-config/releases/tag/v11.1.0

--- a/packages/commonjs/package.json
+++ b/packages/commonjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/eslint-config-commonjs",
-  "version": "11.2.0",
+  "version": "11.1.0",
   "description": "Shareable MetaMask ESLint config for CommonJS projects.",
   "homepage": "https://github.com/MetaMask/eslint-config#readme",
   "bugs": {

--- a/packages/jest/CHANGELOG.md
+++ b/packages/jest/CHANGELOG.md
@@ -6,10 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [11.2.0]
-### Added
-- Add `eslint-plugin-promise` and enable `no-multiple-resolved` ([#287](https://github.com/MetaMask/eslint-config/pull/287))
-
 ## [11.1.0]
 ### Changed
 - Exclude test files from package ([#266](https://github.com/MetaMask/eslint-config/pull/266))
@@ -59,8 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - To continue extending this config, install this package and update your `.eslintrc.js` `extends` array to include `@metamask/eslint-config-jest` instead of `@metamask/eslint-config/jest`.
 - Update `eslint` and other ESLint peer dependencies ([#151](https://github.com/MetaMask/eslint-config/pull/151))
 
-[Unreleased]: https://github.com/MetaMask/eslint-config/compare/v11.2.0...HEAD
-[11.2.0]: https://github.com/MetaMask/eslint-config/compare/v11.1.0...v11.2.0
+[Unreleased]: https://github.com/MetaMask/eslint-config/compare/v11.1.0...HEAD
 [11.1.0]: https://github.com/MetaMask/eslint-config/compare/v11.0.0...v11.1.0
 [11.0.0]: https://github.com/MetaMask/eslint-config/compare/v10.0.0...v11.0.0
 [10.0.0]: https://github.com/MetaMask/eslint-config/compare/v9.0.0...v10.0.0

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/eslint-config-jest",
-  "version": "11.2.0",
+  "version": "11.1.0",
   "description": "Shareable MetaMask ESLint config for Jest.",
   "homepage": "https://github.com/MetaMask/eslint-config#readme",
   "bugs": {

--- a/packages/mocha/CHANGELOG.md
+++ b/packages/mocha/CHANGELOG.md
@@ -6,10 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [11.2.0]
-### Added
-- Add `eslint-plugin-promise` and enable `no-multiple-resolved` ([#287](https://github.com/MetaMask/eslint-config/pull/287))
-
 ## [11.1.0]
 ### Changed
 - Exclude test files from package ([#266](https://github.com/MetaMask/eslint-config/pull/266))
@@ -61,8 +57,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - To continue extending this config, install this package and update your `.eslintrc.js` `extends` array to include `@metamask/eslint-config-mocha` instead of `@metamask/eslint-config/mocha`.
 - Update `eslint` and other ESLint peer dependencies ([#151](https://github.com/MetaMask/eslint-config/pull/151))
 
-[Unreleased]: https://github.com/MetaMask/eslint-config/compare/v11.2.0...HEAD
-[11.2.0]: https://github.com/MetaMask/eslint-config/compare/v11.1.0...v11.2.0
+[Unreleased]: https://github.com/MetaMask/eslint-config/compare/v11.1.0...HEAD
 [11.1.0]: https://github.com/MetaMask/eslint-config/compare/v11.0.0...v11.1.0
 [11.0.0]: https://github.com/MetaMask/eslint-config/compare/v10.0.0...v11.0.0
 [10.0.0]: https://github.com/MetaMask/eslint-config/compare/v9.0.0...v10.0.0

--- a/packages/mocha/package.json
+++ b/packages/mocha/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/eslint-config-mocha",
-  "version": "11.2.0",
+  "version": "11.1.0",
   "description": "Shareable MetaMask ESLint config for Mocha.",
   "homepage": "https://github.com/MetaMask/eslint-config#readme",
   "bugs": {

--- a/packages/nodejs/CHANGELOG.md
+++ b/packages/nodejs/CHANGELOG.md
@@ -6,13 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [11.2.0]
-### Added
-- Add `eslint-plugin-promise` and enable `no-multiple-resolved` ([#287](https://github.com/MetaMask/eslint-config/pull/287))
-
-### Changed
-- Replace `eslint-plugin-node` with `eslint-plugin-n` ([#297](https://github.com/MetaMask/eslint-config/pull/297))
-
 ## [11.1.0]
 ### Changed
 - Exclude test files from package ([#266](https://github.com/MetaMask/eslint-config/pull/266))
@@ -73,8 +66,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - To continue extending this config, install this package and update your `.eslintrc.js` `extends` array to include `@metamask/eslint-config-nodejs` instead of `@metamask/eslint-config/nodejs`.
 - Update `eslint` and other ESLint peer dependencies ([#151](https://github.com/MetaMask/eslint-config/pull/151))
 
-[Unreleased]: https://github.com/MetaMask/eslint-config/compare/v11.2.0...HEAD
-[11.2.0]: https://github.com/MetaMask/eslint-config/compare/v11.1.0...v11.2.0
+[Unreleased]: https://github.com/MetaMask/eslint-config/compare/v11.1.0...HEAD
 [11.1.0]: https://github.com/MetaMask/eslint-config/compare/v11.0.1...v11.1.0
 [11.0.1]: https://github.com/MetaMask/eslint-config/compare/v11.0.0...v11.0.1
 [11.0.0]: https://github.com/MetaMask/eslint-config/compare/v10.0.0...v11.0.0

--- a/packages/nodejs/package.json
+++ b/packages/nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/eslint-config-nodejs",
-  "version": "11.2.0",
+  "version": "11.1.0",
   "description": "Shareable MetaMask ESLint config for Node.js.",
   "homepage": "https://github.com/MetaMask/eslint-config#readme",
   "bugs": {

--- a/packages/typescript/CHANGELOG.md
+++ b/packages/typescript/CHANGELOG.md
@@ -6,16 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [11.2.0]
-### Added
-- Add rule to enforce generic parameters have a length of at least 3 characters ([#292](https://github.com/MetaMask/eslint-config/pull/292))
-- Add `eslint-plugin-promise` and enable `no-multiple-resolved` ([#287](https://github.com/MetaMask/eslint-config/pull/287))
-- Enable `@typescript-eslint/consistent-type-imports` rule ([#284](https://github.com/MetaMask/eslint-config/pull/284))
-- Enable `@typescript-eslint/prefer-enum-initializers` rule ([#269](https://github.com/MetaMask/eslint-config/pull/269))
-
-### Changed
-- Disable naming convention for properties that require quotes ([#293](https://github.com/MetaMask/eslint-config/pull/293))
-
 ## [11.1.0]
 ### Changed
 - Exclude test files from package ([#266](https://github.com/MetaMask/eslint-config/pull/266))
@@ -103,8 +93,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - To continue extending this config, install this package and update your `.eslintrc.js` `extends` array to include `@metamask/eslint-config-typescript` instead of `@metamask/eslint-config/typescript`.
 - Update `eslint` and other ESLint peer dependencies ([#151](https://github.com/MetaMask/eslint-config/pull/151))
 
-[Unreleased]: https://github.com/MetaMask/eslint-config/compare/v11.2.0...HEAD
-[11.2.0]: https://github.com/MetaMask/eslint-config/compare/v11.1.0...v11.2.0
+[Unreleased]: https://github.com/MetaMask/eslint-config/compare/v11.1.0...HEAD
 [11.1.0]: https://github.com/MetaMask/eslint-config/compare/v11.0.2...v11.1.0
 [11.0.2]: https://github.com/MetaMask/eslint-config/compare/v11.0.0...v11.0.2
 [11.0.0]: https://github.com/MetaMask/eslint-config/compare/v10.0.0...v11.0.0

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/eslint-config-typescript",
-  "version": "11.2.0",
+  "version": "11.1.0",
   "description": "Shareable MetaMask ESLint config for TypeScript.",
   "homepage": "https://github.com/MetaMask/eslint-config#readme",
   "bugs": {


### PR DESCRIPTION
Reverts MetaMask/eslint-config#298

We'll release this as v12 instead in the next PR