### PR TITLE
Fix `@metamask/commonjs` peer dependencies

### DIFF
--- a/packages/commonjs/package.json
+++ b/packages/commonjs/package.json
@@ -31,12 +31,8 @@
     "prettier": "^2.7.1"
   },
   "peerDependencies": {
-    "eslint": "^8.27.0",
-    "eslint-config-prettier": "^8.5.0",
-    "eslint-plugin-import": "^2.26.0",
-    "eslint-plugin-jsdoc": "^39.6.2",
-    "eslint-plugin-prettier": "^4.2.1",
-    "prettier": "^2.7.1"
+    "@metamask/eslint-config": "^11.0.0",
+    "eslint": "^8.27.0"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -915,12 +915,8 @@ __metadata:
     eslint-plugin-prettier: ^4.2.1
     prettier: ^2.7.1
   peerDependencies:
+    "@metamask/eslint-config": ^11.0.0
     eslint: ^8.27.0
-    eslint-config-prettier: ^8.5.0
-    eslint-plugin-import: ^2.26.0
-    eslint-plugin-jsdoc: ^39.6.2
-    eslint-plugin-prettier: ^4.2.1
-    prettier: ^2.7.1
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
The peer dependencies for `@metamask/commonjs` were accidentally duplicated from the base configuration when that package was created. They have been updated to refer just to ESLint and to the base config itself, as all the other config packages do.