### PR TITLE
Use `eslint-plugin-import`@`~2.26.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@types/jest": "^29.5.2",
     "eslint": "^8.27.0",
     "eslint-config-prettier": "^8.5.0",
-    "eslint-plugin-import": "^2.27.5",
+    "eslint-plugin-import": "~2.26.0",
     "eslint-plugin-jest": "^27.1.5",
     "eslint-plugin-jsdoc": "^41.1.2",
     "eslint-plugin-n": "^15.7.0",

--- a/packages/base/README.md
+++ b/packages/base/README.md
@@ -11,7 +11,7 @@ yarn add --dev \
     @metamask/eslint-config@^12.0.0 \
     eslint@^8.27.0 \
     eslint-config-prettier@^8.5.0 \
-    eslint-plugin-import@^2.27.5 \
+    eslint-plugin-import@~2.26.0 \
     eslint-plugin-jsdoc@^41.1.2 \
     eslint-plugin-prettier@^4.2.1 \
     eslint-plugin-promise@^6.1.1 \

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -25,7 +25,7 @@
     "@metamask/auto-changelog": "^3.0.0",
     "eslint": "^8.27.0",
     "eslint-config-prettier": "^8.5.0",
-    "eslint-plugin-import": "^2.27.5",
+    "eslint-plugin-import": "~2.26.0",
     "eslint-plugin-jsdoc": "^41.1.2",
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-promise": "^6.1.1",
@@ -34,7 +34,7 @@
   "peerDependencies": {
     "eslint": "^8.27.0",
     "eslint-config-prettier": "^8.5.0",
-    "eslint-plugin-import": "^2.27.5",
+    "eslint-plugin-import": "~2.26.0",
     "eslint-plugin-jsdoc": "^39.6.2 || ^41",
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-promise": "^6.1.1",

--- a/packages/browser/README.md
+++ b/packages/browser/README.md
@@ -12,7 +12,7 @@ yarn add --dev \
     @metamask/eslint-config-browser@^12.0.0 \
     eslint@^8.27.0 \
     eslint-config-prettier@^8.5.0 \
-    eslint-plugin-import@^2.27.5 \
+    eslint-plugin-import@~2.26.0 \
     eslint-plugin-jsdoc@^41.1.2 \
     eslint-plugin-prettier@^4.2.1 \
     eslint-plugin-promise@^6.1.1 \

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -25,7 +25,7 @@
     "@metamask/auto-changelog": "^3.0.0",
     "eslint": "^8.27.0",
     "eslint-config-prettier": "^8.5.0",
-    "eslint-plugin-import": "^2.27.5",
+    "eslint-plugin-import": "~2.26.0",
     "eslint-plugin-jsdoc": "^41.1.2",
     "eslint-plugin-prettier": "^4.2.1",
     "prettier": "^2.7.1"

--- a/packages/commonjs/README.md
+++ b/packages/commonjs/README.md
@@ -10,7 +10,7 @@ yarn add --dev \
     @metamask/eslint-config-commonjs@^12.0.0 \
     eslint@^8.27.0 \
     eslint-config-prettier@^8.5.0 \
-    eslint-plugin-import@^2.27.5 \
+    eslint-plugin-import@~2.26.0 \
     eslint-plugin-jsdoc@^41.1.2 \
     eslint-plugin-prettier@^4.2.1 \
     eslint-plugin-promise@^6.1.1 \

--- a/packages/commonjs/package.json
+++ b/packages/commonjs/package.json
@@ -25,7 +25,7 @@
     "@metamask/auto-changelog": "^3.0.0",
     "eslint": "^8.27.0",
     "eslint-config-prettier": "^8.5.0",
-    "eslint-plugin-import": "^2.27.5",
+    "eslint-plugin-import": "~2.26.0",
     "eslint-plugin-jsdoc": "^41.1.2",
     "eslint-plugin-prettier": "^4.2.1",
     "prettier": "^2.7.1"

--- a/packages/jest/README.md
+++ b/packages/jest/README.md
@@ -10,7 +10,7 @@ yarn add --dev \
     @metamask/eslint-config-jest@^12.0.0 \
     eslint@^8.27.0 \
     eslint-config-prettier@^8.5.0 \
-    eslint-plugin-import@^2.27.5 \
+    eslint-plugin-import@~2.26.0 \
     eslint-plugin-jsdoc@^41.1.2 \
     eslint-plugin-jest@^27.1.5 \
     eslint-plugin-prettier@^4.2.1 \

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -26,7 +26,7 @@
     "@metamask/eslint-config": "^12.0.0",
     "eslint": "^8.27.0",
     "eslint-config-prettier": "^8.5.0",
-    "eslint-plugin-import": "^2.27.5",
+    "eslint-plugin-import": "~2.26.0",
     "eslint-plugin-jest": "^27.1.5",
     "eslint-plugin-jsdoc": "^41.1.2",
     "eslint-plugin-prettier": "^4.2.1",

--- a/packages/mocha/README.md
+++ b/packages/mocha/README.md
@@ -10,7 +10,7 @@ yarn add --dev \
     @metamask/eslint-config-mocha@^12.0.0 \
     eslint@^8.27.0 \
     eslint-config-prettier@^8.5.0 \
-    eslint-plugin-import@^2.27.5 \
+    eslint-plugin-import@~2.26.0 \
     eslint-plugin-jsdoc@^41.1.2 \
     eslint-plugin-mocha@^10.1.0 \
     eslint-plugin-prettier@^4.2.1 \

--- a/packages/mocha/package.json
+++ b/packages/mocha/package.json
@@ -26,7 +26,7 @@
     "@metamask/eslint-config": "^12.0.0",
     "eslint": "^8.27.0",
     "eslint-config-prettier": "^8.5.0",
-    "eslint-plugin-import": "^2.27.5",
+    "eslint-plugin-import": "~2.26.0",
     "eslint-plugin-jsdoc": "^41.1.2",
     "eslint-plugin-mocha": "^10.1.0",
     "eslint-plugin-prettier": "^4.2.1",

--- a/packages/nodejs/README.md
+++ b/packages/nodejs/README.md
@@ -10,7 +10,7 @@ yarn add --dev \
     @metamask/eslint-config-nodejs@^12.0.0 \
     eslint@^8.27.0 \
     eslint-config-prettier@^8.5.0 \
-    eslint-plugin-import@^2.27.5 \
+    eslint-plugin-import@~2.26.0 \
     eslint-plugin-jsdoc@^41.1.2 \
     eslint-plugin-n@^15.7.0 \
     eslint-plugin-prettier@^4.2.1 \

--- a/packages/nodejs/package.json
+++ b/packages/nodejs/package.json
@@ -26,7 +26,7 @@
     "@metamask/eslint-config": "^12.0.0",
     "eslint": "^8.27.0",
     "eslint-config-prettier": "^8.5.0",
-    "eslint-plugin-import": "^2.27.5",
+    "eslint-plugin-import": "~2.26.0",
     "eslint-plugin-jsdoc": "^41.1.2",
     "eslint-plugin-n": "^15.7.0",
     "eslint-plugin-prettier": "^4.2.1",

--- a/packages/typescript/README.md
+++ b/packages/typescript/README.md
@@ -12,7 +12,7 @@ yarn add --dev \
     @typescript-eslint/parser@^5.42.1 \
     eslint@^8.27.0 \
     eslint-config-prettier@^8.5.0 \
-    eslint-plugin-import@^2.27.5 \
+    eslint-plugin-import@~2.26.0 \
     eslint-plugin-jsdoc@^41.1.2 \
     eslint-plugin-prettier@^4.2.1 \
     eslint-plugin-promise@^6.1.1 \

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -29,7 +29,7 @@
     "@typescript-eslint/parser": "^5.42.1",
     "eslint": "^8.27.0",
     "eslint-config-prettier": "^8.5.0",
-    "eslint-plugin-import": "^2.27.5",
+    "eslint-plugin-import": "~2.26.0",
     "eslint-plugin-jsdoc": "^41.1.2",
     "eslint-plugin-prettier": "^4.2.1",
     "prettier": "^2.7.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -851,7 +851,7 @@ __metadata:
     "@metamask/auto-changelog": ^3.0.0
     eslint: ^8.27.0
     eslint-config-prettier: ^8.5.0
-    eslint-plugin-import: ^2.27.5
+    eslint-plugin-import: ~2.26.0
     eslint-plugin-jsdoc: ^41.1.2
     eslint-plugin-prettier: ^4.2.1
     prettier: ^2.7.1
@@ -868,7 +868,7 @@ __metadata:
     "@metamask/auto-changelog": ^3.0.0
     eslint: ^8.27.0
     eslint-config-prettier: ^8.5.0
-    eslint-plugin-import: ^2.27.5
+    eslint-plugin-import: ~2.26.0
     eslint-plugin-jsdoc: ^41.1.2
     eslint-plugin-prettier: ^4.2.1
     prettier: ^2.7.1
@@ -886,7 +886,7 @@ __metadata:
     "@metamask/eslint-config": ^12.0.0
     eslint: ^8.27.0
     eslint-config-prettier: ^8.5.0
-    eslint-plugin-import: ^2.27.5
+    eslint-plugin-import: ~2.26.0
     eslint-plugin-jest: ^27.1.5
     eslint-plugin-jsdoc: ^41.1.2
     eslint-plugin-prettier: ^4.2.1
@@ -906,7 +906,7 @@ __metadata:
     "@metamask/eslint-config": ^12.0.0
     eslint: ^8.27.0
     eslint-config-prettier: ^8.5.0
-    eslint-plugin-import: ^2.27.5
+    eslint-plugin-import: ~2.26.0
     eslint-plugin-jsdoc: ^41.1.2
     eslint-plugin-mocha: ^10.1.0
     eslint-plugin-prettier: ^4.2.1
@@ -926,7 +926,7 @@ __metadata:
     "@metamask/eslint-config": ^12.0.0
     eslint: ^8.27.0
     eslint-config-prettier: ^8.5.0
-    eslint-plugin-import: ^2.27.5
+    eslint-plugin-import: ~2.26.0
     eslint-plugin-jsdoc: ^41.1.2
     eslint-plugin-n: ^15.7.0
     eslint-plugin-prettier: ^4.2.1
@@ -948,7 +948,7 @@ __metadata:
     "@typescript-eslint/parser": ^5.42.1
     eslint: ^8.27.0
     eslint-config-prettier: ^8.5.0
-    eslint-plugin-import: ^2.27.5
+    eslint-plugin-import: ~2.26.0
     eslint-plugin-jsdoc: ^41.1.2
     eslint-plugin-prettier: ^4.2.1
     prettier: ^2.7.1
@@ -969,7 +969,7 @@ __metadata:
     "@metamask/auto-changelog": ^3.0.0
     eslint: ^8.27.0
     eslint-config-prettier: ^8.5.0
-    eslint-plugin-import: ^2.27.5
+    eslint-plugin-import: ~2.26.0
     eslint-plugin-jsdoc: ^41.1.2
     eslint-plugin-prettier: ^4.2.1
     eslint-plugin-promise: ^6.1.1
@@ -977,7 +977,7 @@ __metadata:
   peerDependencies:
     eslint: ^8.27.0
     eslint-config-prettier: ^8.5.0
-    eslint-plugin-import: ^2.27.5
+    eslint-plugin-import: ~2.26.0
     eslint-plugin-jsdoc: ^39.6.2 || ^41
     eslint-plugin-prettier: ^4.2.1
     eslint-plugin-promise: ^6.1.1
@@ -1624,7 +1624,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"array-includes@npm:^3.1.6":
+"array-includes@npm:^3.1.4":
   version: 3.1.6
   resolution: "array-includes@npm:3.1.6"
   dependencies:
@@ -1644,7 +1644,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"array.prototype.flat@npm:^1.3.1":
+"array.prototype.flat@npm:^1.2.5":
   version: 1.3.1
   resolution: "array.prototype.flat@npm:1.3.1"
   dependencies:
@@ -1653,18 +1653,6 @@ __metadata:
     es-abstract: ^1.20.4
     es-shim-unscopables: ^1.0.0
   checksum: 5a8415949df79bf6e01afd7e8839bbde5a3581300e8ad5d8449dea52639e9e59b26a467665622783697917b43bf39940a6e621877c7dd9b3d1c1f97484b9b88b
-  languageName: node
-  linkType: hard
-
-"array.prototype.flatmap@npm:^1.3.1":
-  version: 1.3.1
-  resolution: "array.prototype.flatmap@npm:1.3.1"
-  dependencies:
-    call-bind: ^1.0.2
-    define-properties: ^1.1.4
-    es-abstract: ^1.20.4
-    es-shim-unscopables: ^1.0.0
-  checksum: 8c1c43a4995f12cf12523436da28515184c753807b3f0bc2ca6c075f71c470b099e2090cc67dba8e5280958fea401c1d0c59e1db0143272aef6cd1103921a987
   languageName: node
   linkType: hard
 
@@ -2108,6 +2096,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"debug@npm:^2.6.9":
+  version: 2.6.9
+  resolution: "debug@npm:2.6.9"
+  dependencies:
+    ms: 2.0.0
+  checksum: d2f51589ca66df60bf36e1fa6e4386b318c3f1e06772280eea5b1ae9fd3d05e9c2b7fd8a7d862457d00853c75b00451aa2d7459b924629ee385287a650f58fe6
+  languageName: node
+  linkType: hard
+
 "debug@npm:^3.2.7":
   version: 3.2.7
   resolution: "debug@npm:3.2.7"
@@ -2382,7 +2379,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-import-resolver-node@npm:^0.3.7":
+"eslint-import-resolver-node@npm:^0.3.6":
   version: 0.3.7
   resolution: "eslint-import-resolver-node@npm:0.3.7"
   dependencies:
@@ -2393,7 +2390,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-module-utils@npm:^2.7.4":
+"eslint-module-utils@npm:^2.7.3":
   version: 2.8.0
   resolution: "eslint-module-utils@npm:2.8.0"
   dependencies:
@@ -2417,28 +2414,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-import@npm:^2.27.5":
-  version: 2.27.5
-  resolution: "eslint-plugin-import@npm:2.27.5"
+"eslint-plugin-import@npm:~2.26.0":
+  version: 2.26.0
+  resolution: "eslint-plugin-import@npm:2.26.0"
   dependencies:
-    array-includes: ^3.1.6
-    array.prototype.flat: ^1.3.1
-    array.prototype.flatmap: ^1.3.1
-    debug: ^3.2.7
+    array-includes: ^3.1.4
+    array.prototype.flat: ^1.2.5
+    debug: ^2.6.9
     doctrine: ^2.1.0
-    eslint-import-resolver-node: ^0.3.7
-    eslint-module-utils: ^2.7.4
+    eslint-import-resolver-node: ^0.3.6
+    eslint-module-utils: ^2.7.3
     has: ^1.0.3
-    is-core-module: ^2.11.0
+    is-core-module: ^2.8.1
     is-glob: ^4.0.3
     minimatch: ^3.1.2
-    object.values: ^1.1.6
-    resolve: ^1.22.1
-    semver: ^6.3.0
+    object.values: ^1.1.5
+    resolve: ^1.22.0
     tsconfig-paths: ^3.14.1
   peerDependencies:
     eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8
-  checksum: f500571a380167e25d72a4d925ef9a7aae8899eada57653e5f3051ec3d3c16d08271fcefe41a30a9a2f4fefc232f066253673ee4ea77b30dba65ae173dade85d
+  checksum: 0bf77ad80339554481eafa2b1967449e1f816b94c7a6f9614ce33fb4083c4e6c050f10d241dd50b4975d47922880a34de1e42ea9d8e6fd663ebb768baa67e655
   languageName: node
   linkType: hard
 
@@ -3438,7 +3433,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-core-module@npm:^2.11.0, is-core-module@npm:^2.12.0":
+"is-core-module@npm:^2.11.0, is-core-module@npm:^2.12.0, is-core-module@npm:^2.8.1":
   version: 2.12.1
   resolution: "is-core-module@npm:2.12.1"
   dependencies:
@@ -4459,6 +4454,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ms@npm:2.0.0":
+  version: 2.0.0
+  resolution: "ms@npm:2.0.0"
+  checksum: 0e6a22b8b746d2e0b65a430519934fefd41b6db0682e3477c10f60c76e947c4c0ad06f63ffdf1d78d335f83edee8c0aa928aa66a36c7cd95b69b26f468d527f4
+  languageName: node
+  linkType: hard
+
 "ms@npm:2.1.2":
   version: 2.1.2
   resolution: "ms@npm:2.1.2"
@@ -4620,7 +4622,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"object.values@npm:^1.1.6":
+"object.values@npm:^1.1.5":
   version: 1.1.6
   resolution: "object.values@npm:1.1.6"
   dependencies:
@@ -4989,7 +4991,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve@npm:^1.20.0, resolve@npm:^1.22.1":
+"resolve@npm:^1.20.0, resolve@npm:^1.22.0, resolve@npm:^1.22.1":
   version: 1.22.3
   resolution: "resolve@npm:1.22.3"
   dependencies:
@@ -5002,7 +5004,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve@patch:resolve@^1.20.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.22.1#~builtin<compat/resolve>":
+"resolve@patch:resolve@^1.20.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.22.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.22.1#~builtin<compat/resolve>":
   version: 1.22.3
   resolution: "resolve@patch:resolve@npm%3A1.22.3#~builtin<compat/resolve>::version=1.22.3&hash=07638b"
   dependencies:
@@ -5053,7 +5055,7 @@ __metadata:
     "@types/jest": ^29.5.2
     eslint: ^8.27.0
     eslint-config-prettier: ^8.5.0
-    eslint-plugin-import: ^2.27.5
+    eslint-plugin-import: ~2.26.0
     eslint-plugin-jest: ^27.1.5
     eslint-plugin-jsdoc: ^41.1.2
     eslint-plugin-n: ^15.7.0


### PR DESCRIPTION
`eslint-plugin-import@2.27.0` has a regression causing import order to change for relative imports within a group.

See: import-js/eslint-plugin-import#2682