### PR TITLE
chore(nodejs): remove peer dep on @metamask/eslint-config

### DIFF
--- a/packages/nodejs/package.json
+++ b/packages/nodejs/package.json
@@ -33,7 +33,6 @@
     "prettier": "^2.7.1"
   },
   "peerDependencies": {
-    "@metamask/eslint-config": "^12.0.0",
     "eslint": "^8.27.0",
     "eslint-plugin-n": "^15.7.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -988,7 +988,6 @@ __metadata:
     eslint-plugin-prettier: ^4.2.1
     prettier: ^2.7.1
   peerDependencies:
-    "@metamask/eslint-config": ^12.0.0
     eslint: ^8.27.0
     eslint-plugin-n: ^15.7.0
   languageName: unknown


### PR DESCRIPTION
This config is _recommended_ to be used alongside `@metamask/eslint-config-nodejs`, but it is not actually referenced anywhere in the configuration.  It should not be a peer dependency.