### PR TITLE
Enforce specification of return types in TypeScript

### DIFF
--- a/packages/typescript/rules-snapshot.json
+++ b/packages/typescript/rules-snapshot.json
@@ -9,6 +9,7 @@
   "@typescript-eslint/consistent-type-exports": "error",
   "@typescript-eslint/consistent-type-imports": "error",
   "@typescript-eslint/default-param-last": "error",
+  "@typescript-eslint/explicit-function-return-type": "error",
   "@typescript-eslint/naming-convention": [
     "error",
     {

--- a/packages/typescript/src/index.js
+++ b/packages/typescript/src/index.js
@@ -43,6 +43,7 @@ module.exports = {
     '@typescript-eslint/consistent-type-assertions': 'error',
     '@typescript-eslint/consistent-type-definitions': ['error', 'type'],
     '@typescript-eslint/consistent-type-imports': 'error',
+    '@typescript-eslint/explicit-function-return-type': 'error',
     '@typescript-eslint/no-explicit-any': 'off',
     '@typescript-eslint/no-namespace': [
       'error',


### PR DESCRIPTION
Enable the `@typescript-eslint/explicit-function-return-type` rule, which enforces that return types are specified for all functions. Being explicit about the return type makes it easier to see it without having to open the code in an editor, and communicating what a function _ought_ to return prevents bugs from sneaking in (in case the return value is not being tested).

---

Extracted from https://github.com/MetaMask/contributor-docs/pull/11#discussion_r1271137143.

Enabling this on `core` would produce 603 violations.

Enabling this on `snaps` would produce 571 violations.