### PR TITLE
peerDeps(base): allow eslint-plugin-jsdoc ^43.0.7

### DIFF
--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -35,7 +35,7 @@
     "eslint": "^8.27.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-import": "~2.26.0",
-    "eslint-plugin-jsdoc": "^39.6.2 || ^41",
+    "eslint-plugin-jsdoc": "^39.6.2 || ^41 || ^43.0.7",
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-promise": "^6.1.1",
     "prettier": "^2.7.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1034,7 +1034,7 @@ __metadata:
     eslint: ^8.27.0
     eslint-config-prettier: ^8.5.0
     eslint-plugin-import: ~2.26.0
-    eslint-plugin-jsdoc: ^39.6.2 || ^41
+    eslint-plugin-jsdoc: ^39.6.2 || ^41 || ^43.0.7
     eslint-plugin-prettier: ^4.2.1
     eslint-plugin-promise: ^6.1.1
     prettier: ^2.7.1


### PR DESCRIPTION
Was previously part of #288 but broken out pending merge of #290. This proceeds with enabling use of `eslint-plugin-promise` v43, which will allow users smoother migration experiences.

https://github.com/MetaMask/eslint-config/pull/288#discussion_r1206732177

Sample woes undone by this:
- https://github.com/MetaMask/eth-sig-util/pull/332
  - Would unblock adding back support and testing for node 20 without further workarounds for the upcoming release
- https://github.com/MetaMask/eth-json-rpc-infura/actions/runs/6146931901/job/16677287123?pr=94