### PR TITLE
Update private name to @metamask/eslint-config-monorepo

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "root",
+  "name": "@metamask/eslint-config-monorepo",
   "version": "12.2.0",
   "private": true,
   "repository": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -981,6 +981,33 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@metamask/eslint-config-monorepo@workspace:.":
+  version: 0.0.0-use.local
+  resolution: "@metamask/eslint-config-monorepo@workspace:."
+  dependencies:
+    "@eslint/eslintrc": ^3.0.2
+    "@eslint/js": ^8.57.0
+    "@lavamoat/allow-scripts": ^3.0.4
+    "@metamask/auto-changelog": ^3.4.4
+    "@metamask/eslint-config": ^12.0.0
+    "@metamask/eslint-config-nodejs": ^12.0.0
+    "@metamask/utils": ^8.4.0
+    "@types/jest": ^29.5.12
+    eslint: ^8.57.0
+    eslint-config-prettier: ^8.5.0
+    eslint-plugin-import: ~2.26.0
+    eslint-plugin-jest: ^27.9.0
+    eslint-plugin-jsdoc: ^47.0.2
+    eslint-plugin-n: ^16.6.2
+    eslint-plugin-prettier: ^4.2.1
+    fast-deep-equal: ^3.1.3
+    globals: ^15.0.0
+    jest: ^29.7.0
+    prettier: ^2.7.1
+    prettier-plugin-packagejson: ^2.2.18
+  languageName: unknown
+  linkType: soft
+
 "@metamask/eslint-config-nodejs@^12.0.0, @metamask/eslint-config-nodejs@workspace:packages/nodejs":
   version: 0.0.0-use.local
   resolution: "@metamask/eslint-config-nodejs@workspace:packages/nodejs"
@@ -5550,33 +5577,6 @@ __metadata:
   checksum: 87f4164e396f0171b0a3386cc1877a817f572148ee13a7e113b238e48e8a9f2f31d009a92ec38a591ff1567d9662c6b67fd8818a2dbbaed74bc26a87a2a4a9a0
   languageName: node
   linkType: hard
-
-"root@workspace:.":
-  version: 0.0.0-use.local
-  resolution: "root@workspace:."
-  dependencies:
-    "@eslint/eslintrc": ^3.0.2
-    "@eslint/js": ^8.57.0
-    "@lavamoat/allow-scripts": ^3.0.4
-    "@metamask/auto-changelog": ^3.4.4
-    "@metamask/eslint-config": ^12.0.0
-    "@metamask/eslint-config-nodejs": ^12.0.0
-    "@metamask/utils": ^8.4.0
-    "@types/jest": ^29.5.12
-    eslint: ^8.57.0
-    eslint-config-prettier: ^8.5.0
-    eslint-plugin-import: ~2.26.0
-    eslint-plugin-jest: ^27.9.0
-    eslint-plugin-jsdoc: ^47.0.2
-    eslint-plugin-n: ^16.6.2
-    eslint-plugin-prettier: ^4.2.1
-    fast-deep-equal: ^3.1.3
-    globals: ^15.0.0
-    jest: ^29.7.0
-    prettier: ^2.7.1
-    prettier-plugin-packagejson: ^2.2.18
-  languageName: unknown
-  linkType: soft
 
 "run-parallel@npm:^1.1.9":
   version: 1.1.9


### PR DESCRIPTION
This way when we enable Slack notifications for new releases, it will be less confusing which package needs to be released.