### PR TITLE
Actually bump min Node to 16.20

### DIFF
--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -41,7 +41,7 @@
     "prettier": "^2.7.1"
   },
   "engines": {
-    "node": ">=14.0.0"
+    "node": "^16.20 || ^18.18 || >=20"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -35,7 +35,7 @@
     "eslint": "^8.27.0"
   },
   "engines": {
-    "node": ">=14.0.0"
+    "node": "^16.20 || ^18.18 || >=20"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/commonjs/package.json
+++ b/packages/commonjs/package.json
@@ -35,7 +35,7 @@
     "eslint": "^8.27.0"
   },
   "engines": {
-    "node": ">=14.0.0"
+    "node": "^16.20 || ^18.18 || >=20"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -38,7 +38,7 @@
     "eslint-plugin-jest": "^27.1.5"
   },
   "engines": {
-    "node": ">=14.0.0"
+    "node": "^16.20 || ^18.18 || >=20"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/mocha/package.json
+++ b/packages/mocha/package.json
@@ -38,7 +38,7 @@
     "eslint-plugin-mocha": "^10.1.0"
   },
   "engines": {
-    "node": ">=14.0.0"
+    "node": "^16.20 || ^18.18 || >=20"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/nodejs/package.json
+++ b/packages/nodejs/package.json
@@ -38,7 +38,7 @@
     "eslint-plugin-n": "^15.7.0"
   },
   "engines": {
-    "node": ">=14.0.0"
+    "node": "^16.20 || ^18.18 || >=20"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -43,7 +43,7 @@
     "typescript": "~4.8.4 || ~5.0 || ~5.1"
   },
   "engines": {
-    "node": ">=14.0.0"
+    "node": "^16.20 || ^18.18 || >=20"
   },
   "publishConfig": {
     "access": "public",


### PR DESCRIPTION
It seems that I forgot this was a monorepo and that if we want to bump the minimum Node, we need to do so for all of the packages in this repo and not just the root package.