### PR TITLE
Drop support for Node.js <18.18

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -26,7 +26,7 @@ jobs:
       - prepare
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.x]
+        node-version: [18.x, 20.x]
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
@@ -57,7 +57,7 @@ jobs:
       - prepare
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.x]
+        node-version: [18.x, 20.x]
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "packageManager": "yarn@3.2.4",
   "engines": {
-    "node": "^16.20 || ^18.18 || >=20"
+    "node": "^18.18 || >=20"
   },
   "lavamoat": {
     "allowScripts": {

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -41,7 +41,7 @@
     "prettier": "^2.7.1"
   },
   "engines": {
-    "node": "^16.20 || ^18.18 || >=20"
+    "node": "^18.18 || >=20"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -35,7 +35,7 @@
     "eslint": "^8.57.0"
   },
   "engines": {
-    "node": "^16.20 || ^18.18 || >=20"
+    "node": "^18.18 || >=20"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/commonjs/package.json
+++ b/packages/commonjs/package.json
@@ -35,7 +35,7 @@
     "eslint": "^8.57.0"
   },
   "engines": {
-    "node": "^16.20 || ^18.18 || >=20"
+    "node": "^18.18 || >=20"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -38,7 +38,7 @@
     "eslint-plugin-jest": "^27.9.0"
   },
   "engines": {
-    "node": "^16.20 || ^18.18 || >=20"
+    "node": "^18.18 || >=20"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/mocha/package.json
+++ b/packages/mocha/package.json
@@ -38,7 +38,7 @@
     "eslint-plugin-mocha": "^10.4.1"
   },
   "engines": {
-    "node": "^16.20 || ^18.18 || >=20"
+    "node": "^18.18 || >=20"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/nodejs/package.json
+++ b/packages/nodejs/package.json
@@ -38,7 +38,7 @@
     "eslint-plugin-n": "^16.6.2"
   },
   "engines": {
-    "node": "^16.20 || ^18.18 || >=20"
+    "node": "^18.18 || >=20"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -43,7 +43,7 @@
     "typescript": ">=4.8.4 <5.6"
   },
   "engines": {
-    "node": "^16.20 || ^18.18 || >=20"
+    "node": "^18.18 || >=20"
   },
   "publishConfig": {
     "access": "public",


### PR DESCRIPTION
Node.js 16 is EOL for some time now, so we can drop support for it. This is also a prerequisite for #370.