### PR TITLE
Revert "Release 14.0.0 (#377)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/eslint-config-root",
-  "version": "14.0.0",
+  "version": "13.0.0",
   "private": true,
   "repository": {
     "type": "git",
@@ -27,8 +27,8 @@
     "@lavamoat/allow-scripts": "^3.0.4",
     "@metamask/auto-changelog": "^3.4.4",
     "@metamask/create-release-branch": "^4.0.0",
-    "@metamask/eslint-config": "workspace:^",
-    "@metamask/eslint-config-nodejs": "workspace:^",
+    "@metamask/eslint-config": "^13.0.0",
+    "@metamask/eslint-config-nodejs": "^13.0.0",
     "@metamask/eslint-config-typescript": "workspace:^",
     "@metamask/eslint-config-vitest": "workspace:^",
     "@metamask/utils": "^9.1.0",

--- a/packages/base/CHANGELOG.md
+++ b/packages/base/CHANGELOG.md
@@ -7,26 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [14.0.0]
-
-### Changed
-
-- **BREAKING:** Bump minimum Node.js version from 16 to 18.18 ([#371](https://github.com/MetaMask/eslint-config/pull/371))
-- **BREAKING:** Bump peer dependency on ESLint from `^8.57.0` to `^9.11.0` ([#370](https://github.com/MetaMask/eslint-config/pull/370))
-  - ESLint 9 requires flat configs, so this change also rewrites the configs to
-    use flat configs. The legacy config format is no longer supported.
-- **BREAKING:** Bump peer dependency on `@metamask/eslint-config` from `^13.0.0` to `^14.0.0` ([#377](https://github.com/MetaMask/eslint-config/pull/377))
-- **BREAKING:** Bump peer dependency on `eslint-config-prettier` from `^8.5.0` to `^9.1.0` ([#370](https://github.com/MetaMask/eslint-config/pull/370))
-- **BREAKING:** Bump peer dependency on `eslint-plugin-import-x` from `^0.5.1` to `^4.3.0` ([#370](https://github.com/MetaMask/eslint-config/pull/370))
-- **BREAKING:** Bump peer dependency on `eslint-plugin-jsdoc` from `>=43.0.7 <48` to `^50.2.4` ([#370](https://github.com/MetaMask/eslint-config/pull/370))
-- **BREAKING:** Bump peer dependency on `eslint-plugin-prettier` from `^4.2.1` to `^5.2.1` ([#370](https://github.com/MetaMask/eslint-config/pull/370))
-- **BREAKING:** Bump peer dependency on `eslint-plugin-promise` from `^6.1.1` to `^7.1.0` ([#370](https://github.com/MetaMask/eslint-config/pull/370))
-- **BREAKING:** Bump peer dependency on `prettier` from `^2.7.1` to `^3.3.3` ([#370](https://github.com/MetaMask/eslint-config/pull/370))
-- **BREAKING:** Change package to be pure ESM ([#370](https://github.com/MetaMask/eslint-config/pull/370))
-  - ESLint 9 supports ESM out-of-the-box, so this change updates the package to
-    be pure ESM. This means that the package can no longer be used with CommonJS
-    `require` syntax.
-
 ## [13.0.0]
 
 ### Changed
@@ -264,8 +244,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add base, TypeScript, and Jest configs (#3)
 
-[Unreleased]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config@14.0.0...HEAD
-[14.0.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config@13.0.0...@metamask/eslint-config@14.0.0
+[Unreleased]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config@13.0.0...HEAD
 [13.0.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config@12.2.0...@metamask/eslint-config@13.0.0
 [12.2.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config@12.1.0...@metamask/eslint-config@12.2.0
 [12.1.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config@12.0.0...@metamask/eslint-config@12.1.0

--- a/packages/base/README.md
+++ b/packages/base/README.md
@@ -8,7 +8,7 @@ Our default export contains a base set of ESLint rules for ES6+:
 
 ```bash
 yarn add --dev \
-    @metamask/eslint-config@^14.0.0 \
+    @metamask/eslint-config@^13.0.0 \
     eslint@^9.11.0 \
     eslint-config-prettier@^9.1.0 \
     eslint-plugin-import-x@^4.3.0 \

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/eslint-config",
-  "version": "14.0.0",
+  "version": "13.0.0",
   "description": "Shareable MetaMask ESLint config.",
   "homepage": "https://github.com/MetaMask/eslint-config#readme",
   "bugs": {

--- a/packages/browser/CHANGELOG.md
+++ b/packages/browser/CHANGELOG.md
@@ -7,20 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [14.0.0]
-
-### Changed
-
-- **BREAKING:** Bump minimum Node.js version from 16 to 18.18 ([#371](https://github.com/MetaMask/eslint-config/pull/371))
-- **BREAKING:** Bump peer dependency on ESLint from `^8.57.0` to `^9.11.0` ([#370](https://github.com/MetaMask/eslint-config/pull/370))
-  - ESLint 9 requires flat configs, so this change also rewrites the configs to
-    use flat configs. The legacy config format is no longer supported.
-- **BREAKING:** Bump peer dependency on `@metamask/eslint-config` from `^13.0.0` to `^14.0.0` ([#377](https://github.com/MetaMask/eslint-config/pull/377))
-- **BREAKING:** Change package to be pure ESM ([#370](https://github.com/MetaMask/eslint-config/pull/370))
-  - ESLint 9 supports ESM out-of-the-box, so this change updates the package to
-    be pure ESM. This means that the package can no longer be used with CommonJS
-    `require` syntax.
-
 ## [13.0.0]
 
 ### Changed
@@ -54,8 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release of this package.
 
-[Unreleased]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-browser@14.0.0...HEAD
-[14.0.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-browser@13.0.0...@metamask/eslint-config-browser@14.0.0
+[Unreleased]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-browser@13.0.0...HEAD
 [13.0.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-browser@12.1.0...@metamask/eslint-config-browser@13.0.0
 [12.1.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-browser@12.0.0...@metamask/eslint-config-browser@12.1.0
 [12.0.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-browser@11.1.0...@metamask/eslint-config-browser@12.0.0

--- a/packages/browser/README.md
+++ b/packages/browser/README.md
@@ -8,8 +8,8 @@ Our default export contains a base set of ESLint rules for ES6+:
 
 ```bash
 yarn add --dev \
-    @metamask/eslint-config@^14.0.0 \
-    @metamask/eslint-config-browser@^14.0.0 \
+    @metamask/eslint-config@^13.0.0 \
+    @metamask/eslint-config-browser@^13.0.0 \
     eslint@^9.11.0 \
     eslint-config-prettier@^9.1.0 \
     eslint-plugin-import-x@^4.3.0 \

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/eslint-config-browser",
-  "version": "14.0.0",
+  "version": "13.0.0",
   "description": "Shareable MetaMask ESLint plugin for browser environments.",
   "homepage": "https://github.com/MetaMask/eslint-config#readme",
   "bugs": {
@@ -48,7 +48,7 @@
     "vitest": "^2.1.1"
   },
   "peerDependencies": {
-    "@metamask/eslint-config": "workspace:^",
+    "@metamask/eslint-config": "^13.0.0",
     "eslint": "^9.11.0"
   },
   "engines": {

--- a/packages/commonjs/CHANGELOG.md
+++ b/packages/commonjs/CHANGELOG.md
@@ -7,20 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [14.0.0]
-
-### Changed
-
-- **BREAKING:** Bump minimum Node.js version from 16 to 18.18 ([#371](https://github.com/MetaMask/eslint-config/pull/371))
-- **BREAKING:** Bump peer dependency on ESLint from `^8.57.0` to `^9.11.0` ([#370](https://github.com/MetaMask/eslint-config/pull/370))
-  - ESLint 9 requires flat configs, so this change also rewrites the configs to
-    use flat configs. The legacy config format is no longer supported.
-- **BREAKING:** Bump peer dependency on `@metamask/eslint-config` from `^13.0.0` to `^14.0.0` ([#377](https://github.com/MetaMask/eslint-config/pull/377))
-- **BREAKING:** Change package to be pure ESM ([#370](https://github.com/MetaMask/eslint-config/pull/370))
-  - ESLint 9 supports ESM out-of-the-box, so this change updates the package to
-    be pure ESM. This means that the package can no longer be used with CommonJS
-    `require` syntax.
-
 ## [13.0.0]
 
 ### Changed
@@ -49,8 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release of this package ([#267](https://github.com/MetaMask/eslint-config/pull/267))
 
-[Unreleased]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-commonjs@14.0.0...HEAD
-[14.0.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-commonjs@13.0.0...@metamask/eslint-config-commonjs@14.0.0
+[Unreleased]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-commonjs@13.0.0...HEAD
 [13.0.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-commonjs@12.1.0...@metamask/eslint-config-commonjs@13.0.0
 [12.1.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-commonjs@12.0.0...@metamask/eslint-config-commonjs@12.1.0
 [12.0.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-commonjs@11.1.0...@metamask/eslint-config-commonjs@12.0.0

--- a/packages/commonjs/README.md
+++ b/packages/commonjs/README.md
@@ -7,7 +7,7 @@ MetaMask's ESLint configuration for projects using CommonJS.
 ```bash
 yarn add --dev \
     @metamask/eslint-config@^13.0.0 \
-    @metamask/eslint-config-commonjs@^14.0.0 \
+    @metamask/eslint-config-commonjs@^13.0.0 \
     eslint@^9.11.0 \
     eslint-config-prettier@^9.1.0 \
     eslint-plugin-import-x@^4.3.0 \

--- a/packages/commonjs/package.json
+++ b/packages/commonjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/eslint-config-commonjs",
-  "version": "14.0.0",
+  "version": "13.0.0",
   "description": "Shareable MetaMask ESLint config for CommonJS projects.",
   "homepage": "https://github.com/MetaMask/eslint-config#readme",
   "bugs": {
@@ -48,7 +48,7 @@
     "vitest": "^2.1.1"
   },
   "peerDependencies": {
-    "@metamask/eslint-config": "workspace:^",
+    "@metamask/eslint-config": "^13.0.0",
     "eslint": "^9.11.0"
   },
   "engines": {

--- a/packages/jest/CHANGELOG.md
+++ b/packages/jest/CHANGELOG.md
@@ -7,21 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [14.0.0]
-
-### Changed
-
-- **BREAKING:** Bump minimum Node.js version from 16 to 18.18 ([#371](https://github.com/MetaMask/eslint-config/pull/371))
-- **BREAKING:** Bump peer dependency on ESLint from `^8.57.0` to `^9.11.0` ([#370](https://github.com/MetaMask/eslint-config/pull/370))
-  - ESLint 9 requires flat configs, so this change also rewrites the configs to
-    use flat configs. The legacy config format is no longer supported.
-- **BREAKING:** Bump peer dependency on `@metamask/eslint-config` from `^13.0.0` to `^14.0.0` ([#377](https://github.com/MetaMask/eslint-config/pull/377))
-- **BREAKING:** Bump peer dependency on `eslint-plugin-jest` from `^27.9.0` to `^28.8.3` ([#370](https://github.com/MetaMask/eslint-config/pull/370))
-- **BREAKING:** Change package to be pure ESM ([#370](https://github.com/MetaMask/eslint-config/pull/370))
-  - ESLint 9 supports ESM out-of-the-box, so this change updates the package to
-    be pure ESM. This means that the package can no longer be used with CommonJS
-    `require` syntax.
-
 ## [13.0.0]
 
 ### Changed
@@ -107,8 +92,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - To continue extending this config, install this package and update your `.eslintrc.js` `extends` array to include `@metamask/eslint-config-jest` instead of `@metamask/eslint-config/jest`.
 - Update `eslint` and other ESLint peer dependencies ([#151](https://github.com/MetaMask/eslint-config/pull/151))
 
-[Unreleased]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-jest@14.0.0...HEAD
-[14.0.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-jest@13.0.0...@metamask/eslint-config-jest@14.0.0
+[Unreleased]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-jest@13.0.0...HEAD
 [13.0.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-jest@12.1.0...@metamask/eslint-config-jest@13.0.0
 [12.1.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-jest@12.0.0...@metamask/eslint-config-jest@12.1.0
 [12.0.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-jest@11.1.0...@metamask/eslint-config-jest@12.0.0

--- a/packages/jest/README.md
+++ b/packages/jest/README.md
@@ -6,8 +6,8 @@ MetaMask's [Jest](https://jestjs.io/) ESLint configuration.
 
 ```bash
 yarn add --dev \
-    @metamask/eslint-config@^14.0.0 \
-    @metamask/eslint-config-jest@^14.0.0 \
+    @metamask/eslint-config@^13.0.0 \
+    @metamask/eslint-config-jest@^13.0.0 \
     eslint@^9.11.0 \
     eslint-config-prettier@^9.1.0 \
     eslint-plugin-import-x@^4.3.0 \

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/eslint-config-jest",
-  "version": "14.0.0",
+  "version": "13.0.0",
   "description": "Shareable MetaMask ESLint config for Jest.",
   "homepage": "https://github.com/MetaMask/eslint-config#readme",
   "bugs": {
@@ -40,7 +40,7 @@
   "devDependencies": {
     "@jest/globals": "^29.7.0",
     "@metamask/auto-changelog": "^3.4.4",
-    "@metamask/eslint-config": "workspace:^",
+    "@metamask/eslint-config": "^13.0.0",
     "eslint": "^9.11.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-import-x": "^4.3.0",
@@ -52,7 +52,7 @@
     "vitest": "^2.1.1"
   },
   "peerDependencies": {
-    "@metamask/eslint-config": "workspace:^",
+    "@metamask/eslint-config": "^13.0.0",
     "eslint": "^9.11.0",
     "eslint-plugin-jest": "^28.8.3"
   },

--- a/packages/mocha/CHANGELOG.md
+++ b/packages/mocha/CHANGELOG.md
@@ -7,21 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [14.0.0]
-
-### Changed
-
-- **BREAKING:** Bump minimum Node.js version from 16 to 18.18 ([#371](https://github.com/MetaMask/eslint-config/pull/371))
-- **BREAKING:** Bump peer dependency on ESLint from `^8.57.0` to `^9.11.0` ([#370](https://github.com/MetaMask/eslint-config/pull/370))
-  - ESLint 9 requires flat configs, so this change also rewrites the configs to
-    use flat configs. The legacy config format is no longer supported.
-- **BREAKING:** Bump peer dependency on `@metamask/eslint-config` from `^13.0.0` to `^14.0.0` ([#377](https://github.com/MetaMask/eslint-config/pull/377))
-- **BREAKING:** Bump peer dependency on `eslint-plugin-mocha` from `^10.4.1` to `^10.5.0` ([#370](https://github.com/MetaMask/eslint-config/pull/370))
-- **BREAKING:** Change package to be pure ESM ([#370](https://github.com/MetaMask/eslint-config/pull/370))
-  - ESLint 9 supports ESM out-of-the-box, so this change updates the package to
-    be pure ESM. This means that the package can no longer be used with CommonJS
-    `require` syntax.
-
 ## [13.0.0]
 
 ### Changed
@@ -109,8 +94,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - To continue extending this config, install this package and update your `.eslintrc.js` `extends` array to include `@metamask/eslint-config-mocha` instead of `@metamask/eslint-config/mocha`.
 - Update `eslint` and other ESLint peer dependencies ([#151](https://github.com/MetaMask/eslint-config/pull/151))
 
-[Unreleased]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-mocha@14.0.0...HEAD
-[14.0.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-mocha@13.0.0...@metamask/eslint-config-mocha@14.0.0
+[Unreleased]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-mocha@13.0.0...HEAD
 [13.0.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-mocha@12.1.0...@metamask/eslint-config-mocha@13.0.0
 [12.1.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-mocha@12.0.0...@metamask/eslint-config-mocha@12.1.0
 [12.0.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-mocha@11.1.0...@metamask/eslint-config-mocha@12.0.0

--- a/packages/mocha/README.md
+++ b/packages/mocha/README.md
@@ -6,8 +6,8 @@ MetaMask's [Mocha](https://mochajs.org/) ESLint configuration.
 
 ```bash
 yarn add --dev \
-    @metamask/eslint-config@^14.0.0 \
-    @metamask/eslint-config-mocha@^14.0.0 \
+    @metamask/eslint-config@^13.0.0 \
+    @metamask/eslint-config-mocha@^13.0.0 \
     eslint@^9.11.0 \
     eslint-config-prettier@^9.1.0 \
     eslint-plugin-import-x@^4.3.0 \

--- a/packages/mocha/package.json
+++ b/packages/mocha/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/eslint-config-mocha",
-  "version": "14.0.0",
+  "version": "13.0.0",
   "description": "Shareable MetaMask ESLint config for Mocha.",
   "homepage": "https://github.com/MetaMask/eslint-config#readme",
   "bugs": {
@@ -38,7 +38,7 @@
   "devDependencies": {
     "@jest/globals": "^29.7.0",
     "@metamask/auto-changelog": "^3.4.4",
-    "@metamask/eslint-config": "workspace:^",
+    "@metamask/eslint-config": "^13.0.0",
     "eslint": "^9.11.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-import-x": "^4.3.0",
@@ -50,7 +50,7 @@
     "vitest": "^2.1.1"
   },
   "peerDependencies": {
-    "@metamask/eslint-config": "workspace:^",
+    "@metamask/eslint-config": "^13.0.0",
     "eslint": "^9.11.0",
     "eslint-plugin-mocha": "^10.5.0"
   },

--- a/packages/nodejs/CHANGELOG.md
+++ b/packages/nodejs/CHANGELOG.md
@@ -7,21 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [14.0.0]
-
-### Changed
-
-- **BREAKING:** Bump minimum Node.js version from 16 to 18.18 ([#371](https://github.com/MetaMask/eslint-config/pull/371))
-- **BREAKING:** Bump peer dependency on ESLint from `^8.57.0` to `^9.11.0` ([#370](https://github.com/MetaMask/eslint-config/pull/370))
-  - ESLint 9 requires flat configs, so this change also rewrites the configs to
-    use flat configs. The legacy config format is no longer supported.
-- **BREAKING:** Bump peer dependency on `@metamask/eslint-config` from `^13.0.0` to `^14.0.0` ([#377](https://github.com/MetaMask/eslint-config/pull/377))
-- **BREAKING:** Bump peer dependency on `eslint-plugin-n` from `^16.6.2` to `^17.10.3` ([#370](https://github.com/MetaMask/eslint-config/pull/370))
-- **BREAKING:** Change package to be pure ESM ([#370](https://github.com/MetaMask/eslint-config/pull/370))
-  - ESLint 9 supports ESM out-of-the-box, so this change updates the package to
-    be pure ESM. This means that the package can no longer be used with CommonJS
-    `require` syntax.
-
 ## [13.0.0]
 
 ### Changed
@@ -123,8 +108,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - To continue extending this config, install this package and update your `.eslintrc.js` `extends` array to include `@metamask/eslint-config-nodejs` instead of `@metamask/eslint-config/nodejs`.
 - Update `eslint` and other ESLint peer dependencies ([#151](https://github.com/MetaMask/eslint-config/pull/151))
 
-[Unreleased]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-nodejs@14.0.0...HEAD
-[14.0.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-nodejs@13.0.0...@metamask/eslint-config-nodejs@14.0.0
+[Unreleased]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-nodejs@13.0.0...HEAD
 [13.0.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-nodejs@12.1.0...@metamask/eslint-config-nodejs@13.0.0
 [12.1.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-nodejs@12.0.0...@metamask/eslint-config-nodejs@12.1.0
 [12.0.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-nodejs@11.1.0...@metamask/eslint-config-nodejs@12.0.0

--- a/packages/nodejs/README.md
+++ b/packages/nodejs/README.md
@@ -6,8 +6,8 @@ MetaMask's [Node.js](https://nodejs.org) ESLint configuration.
 
 ```bash
 yarn add --dev \
-    @metamask/eslint-config@^14.0.0 \
-    @metamask/eslint-config-nodejs@^14.0.0 \
+    @metamask/eslint-config@^13.0.0 \
+    @metamask/eslint-config-nodejs@^12.1.0 \
     eslint@^9.11.0 \
     eslint-config-prettier@^9.1.0 \
     eslint-plugin-import-x@^4.3.0 \

--- a/packages/nodejs/package.json
+++ b/packages/nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/eslint-config-nodejs",
-  "version": "14.0.0",
+  "version": "13.0.0",
   "description": "Shareable MetaMask ESLint config for Node.js.",
   "homepage": "https://github.com/MetaMask/eslint-config#readme",
   "bugs": {
@@ -39,7 +39,7 @@
   "devDependencies": {
     "@jest/globals": "^29.7.0",
     "@metamask/auto-changelog": "^3.4.4",
-    "@metamask/eslint-config": "workspace:^",
+    "@metamask/eslint-config": "^13.0.0",
     "eslint": "^9.11.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-import-x": "^4.3.0",
@@ -50,7 +50,7 @@
     "vitest": "^2.1.1"
   },
   "peerDependencies": {
-    "@metamask/eslint-config": "workspace:^",
+    "@metamask/eslint-config": "^13.0.0",
     "eslint": "^9.11.0",
     "eslint-plugin-n": "^17.10.3"
   },

--- a/packages/typescript/CHANGELOG.md
+++ b/packages/typescript/CHANGELOG.md
@@ -7,41 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [14.0.0]
-
-### Added
-
-- **BREAKING:** Add peer dependency on `typescript-eslint@^8.6.0`. ([#370](https://github.com/MetaMask/eslint-config/pull/370))
-- **BREAKING:** Add peer dependency on `eslint-import-resolver-typescript@^3.6.3` ([#370](https://github.com/MetaMask/eslint-config/pull/370))
-- **BREAKING:** Add peer dependency on `eslint-plugin-import-x@^4.3.0` ([#370](https://github.com/MetaMask/eslint-config/pull/370))
-- **BREAKING:** Add peer dependency on `eslint-plugin-jsdoc@^50.2.4` ([#370](https://github.com/MetaMask/eslint-config/pull/370))
-
-### Changed
-
-- **BREAKING:** Bump minimum Node.js version from 16 to 18.18 ([#371](https://github.com/MetaMask/eslint-config/pull/371))
-- **BREAKING:** Bump peer dependency on ESLint from `^8.57.0` to `^9.11.0` ([#370](https://github.com/MetaMask/eslint-config/pull/370))
-  - ESLint 9 requires flat configs, so this change also rewrites the configs to
-    use flat configs. The legacy config format is no longer supported.
-- **BREAKING:** Bump peer dependency on `@metamask/eslint-config` from `^13.0.0` to `^14.0.0` ([#377](https://github.com/MetaMask/eslint-config/pull/377))
-- **BREAKING:** Change package to be pure ESM ([#370](https://github.com/MetaMask/eslint-config/pull/370))
-  - ESLint 9 supports ESM out-of-the-box, so this change updates the package to
-    be pure ESM. This means that the package can no longer be used with CommonJS
-    `require` syntax.
-
-### Removed
-
-- Remove peer dependency on `@typescript-eslint/eslint-plugin` and `@typescript-eslint/parser` ([#370](https://github.com/MetaMask/eslint-config/pull/370))
-
 ## [13.0.0]
 
 ### Changed
 
-- **BREAKING:** Bump TypeScript to v5.5 ([#364](https://github.com/MetaMask/eslint-config/pull/364))
+- **BREAKING**: Bump TypeScript to v5.5 ([#364](https://github.com/MetaMask/eslint-config/pull/364))
   - Also bump relevant `@typescript-eslint` packages.
-- **BREAKING:** Replace `eslint-plugin-import` with `eslint-plugin-import-x` ([#366](https://github.com/MetaMask/eslint-config/pull/366))
-- **BREAKING:** Bump all ESLint dependencies ([#351](https://github.com/MetaMask/eslint-config/pull/351))
+- **BREAKING**: Replace `eslint-plugin-import` with `eslint-plugin-import-x` ([#366](https://github.com/MetaMask/eslint-config/pull/366))
+- **BREAKING**: Bump all ESLint dependencies ([#351](https://github.com/MetaMask/eslint-config/pull/351))
   - Bumps all ESLint dependencies to the latest version compatible with Node.js 16.
-- **BREAKING:** Bump minimum Node.js version from 14 to 16 ([#332](https://github.com/MetaMask/eslint-config/pull/332), [#339](https://github.com/MetaMask/eslint-config/pull/339))
+- **BREAKING**: Bump minimum Node.js version from 14 to 16 ([#332](https://github.com/MetaMask/eslint-config/pull/332), [#339](https://github.com/MetaMask/eslint-config/pull/339))
 
 ## [12.1.0]
 
@@ -171,8 +146,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - To continue extending this config, install this package and update your `.eslintrc.js` `extends` array to include `@metamask/eslint-config-typescript` instead of `@metamask/eslint-config/typescript`.
 - Update `eslint` and other ESLint peer dependencies ([#151](https://github.com/MetaMask/eslint-config/pull/151))
 
-[Unreleased]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-typescript@14.0.0...HEAD
-[14.0.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-typescript@13.0.0...@metamask/eslint-config-typescript@14.0.0
+[Unreleased]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-typescript@13.0.0...HEAD
 [13.0.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-typescript@12.1.0...@metamask/eslint-config-typescript@13.0.0
 [12.1.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-typescript@12.0.0...@metamask/eslint-config-typescript@12.1.0
 [12.0.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-typescript@11.1.0...@metamask/eslint-config-typescript@12.0.0

--- a/packages/typescript/README.md
+++ b/packages/typescript/README.md
@@ -6,8 +6,8 @@ MetaMask's [TypeScript](https://www.typescriptlang.org) ESLint configuration.
 
 ```bash
 yarn add --dev \
-    @metamask/eslint-config@^14.0.0 \
-    @metamask/eslint-config-typescript@^14.0.0 \
+    @metamask/eslint-config@^13.0.0 \
+    @metamask/eslint-config-typescript@^13.0.0 \
     eslint@^9.11.0 \
     eslint-config-prettier@^9.1.0 \
     eslint-plugin-import-x@^4.3.0 \

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/eslint-config-typescript",
-  "version": "14.0.0",
+  "version": "13.0.0",
   "description": "Shareable MetaMask ESLint config for TypeScript.",
   "homepage": "https://github.com/MetaMask/eslint-config#readme",
   "bugs": {
@@ -39,7 +39,7 @@
   "devDependencies": {
     "@jest/globals": "^29.7.0",
     "@metamask/auto-changelog": "^3.4.4",
-    "@metamask/eslint-config": "workspace:^",
+    "@metamask/eslint-config": "^13.0.0",
     "eslint": "^9.11.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-import-resolver-typescript": "^3.6.3",
@@ -53,7 +53,7 @@
     "vitest": "^2.1.1"
   },
   "peerDependencies": {
-    "@metamask/eslint-config": "workspace:^",
+    "@metamask/eslint-config": "^13.0.0",
     "eslint": "^9.11.0",
     "eslint-import-resolver-typescript": "^3.6.3",
     "eslint-plugin-import-x": "^4.3.0",

--- a/packages/vitest/CHANGELOG.md
+++ b/packages/vitest/CHANGELOG.md
@@ -7,13 +7,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.0.0]
-
-### Added
-
-- Add Vitest config ([#373](https://github.com/MetaMask/eslint-config/pull/373))
-  - This config is based on the `@metamask/eslint-config-jest` config, but uses
-    the Vitest plugin instead of Jest.
-
-[Unreleased]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-vitest@1.0.0...HEAD
-[1.0.0]: https://github.com/MetaMask/eslint-config/releases/tag/@metamask/eslint-config-vitest@1.0.0
+[Unreleased]: https://github.com/MetaMask/eslint-config/

--- a/packages/vitest/README.md
+++ b/packages/vitest/README.md
@@ -6,8 +6,8 @@ MetaMask's [Vitest](https://vitest.dev/) ESLint configuration.
 
 ```bash
 yarn add --dev \
-    @metamask/eslint-config@^14.0.0 \
-    @metamask/eslint-config-vitest@^1.0.0 \
+    @metamask/eslint-config@^13.0.0 \
+    @metamask/eslint-config-vitest@^0.0.0 \
     @vitest/eslint-plugin@^1.1.4 \
     eslint@^9.11.0 \
     eslint-config-prettier@^9.1.0 \

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/eslint-config-vitest",
-  "version": "1.0.0",
+  "version": "0.0.0",
   "description": "Shareable MetaMask ESLint config for Vitest.",
   "homepage": "https://github.com/MetaMask/eslint-config#readme",
   "bugs": {
@@ -28,7 +28,7 @@
   ],
   "scripts": {
     "changelog:update": "../../scripts/update-changelog.sh @metamask/eslint-config-vitest",
-    "changelog:validate": "../../scripts/validate-changelog.sh @metamask/eslint-config-vitest",
+    "changelog:validate": "../../scripts/validate-changelog.sh @metamask/eslint-config-vitests",
     "publish": "npm publish",
     "test": "eslint ."
   },
@@ -39,7 +39,7 @@
   "devDependencies": {
     "@jest/globals": "^29.7.0",
     "@metamask/auto-changelog": "^3.4.4",
-    "@metamask/eslint-config": "workspace:^",
+    "@metamask/eslint-config": "^13.0.0",
     "@vitest/eslint-plugin": "^1.1.4",
     "eslint": "^9.11.0",
     "eslint-config-prettier": "^9.1.0",
@@ -51,7 +51,7 @@
     "vitest": "^2.1.1"
   },
   "peerDependencies": {
-    "@metamask/eslint-config": "workspace:^",
+    "@metamask/eslint-config": "^13.0.0",
     "@vitest/eslint-plugin": "^1.1.4",
     "eslint": "^9.11.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1129,7 +1129,7 @@ __metadata:
     prettier: "npm:^3.3.3"
     vitest: "npm:^2.1.1"
   peerDependencies:
-    "@metamask/eslint-config": "workspace:^"
+    "@metamask/eslint-config": ^13.0.0
     eslint: ^9.11.0
   languageName: unknown
   linkType: soft
@@ -1150,7 +1150,7 @@ __metadata:
     prettier: "npm:^3.3.3"
     vitest: "npm:^2.1.1"
   peerDependencies:
-    "@metamask/eslint-config": "workspace:^"
+    "@metamask/eslint-config": ^13.0.0
     eslint: ^9.11.0
   languageName: unknown
   linkType: soft
@@ -1162,7 +1162,7 @@ __metadata:
     "@eslint/js": "npm:^9.11.0"
     "@jest/globals": "npm:^29.7.0"
     "@metamask/auto-changelog": "npm:^3.4.4"
-    "@metamask/eslint-config": "workspace:^"
+    "@metamask/eslint-config": "npm:^13.0.0"
     eslint: "npm:^9.11.0"
     eslint-config-prettier: "npm:^9.1.0"
     eslint-plugin-import-x: "npm:^4.3.0"
@@ -1174,7 +1174,7 @@ __metadata:
     prettier: "npm:^3.3.3"
     vitest: "npm:^2.1.1"
   peerDependencies:
-    "@metamask/eslint-config": "workspace:^"
+    "@metamask/eslint-config": ^13.0.0
     eslint: ^9.11.0
     eslint-plugin-jest: ^28.8.3
   languageName: unknown
@@ -1187,7 +1187,7 @@ __metadata:
     "@eslint/js": "npm:^9.11.0"
     "@jest/globals": "npm:^29.7.0"
     "@metamask/auto-changelog": "npm:^3.4.4"
-    "@metamask/eslint-config": "workspace:^"
+    "@metamask/eslint-config": "npm:^13.0.0"
     eslint: "npm:^9.11.0"
     eslint-config-prettier: "npm:^9.1.0"
     eslint-plugin-import-x: "npm:^4.3.0"
@@ -1198,20 +1198,20 @@ __metadata:
     prettier: "npm:^3.3.3"
     vitest: "npm:^2.1.1"
   peerDependencies:
-    "@metamask/eslint-config": "workspace:^"
+    "@metamask/eslint-config": ^13.0.0
     eslint: ^9.11.0
     eslint-plugin-mocha: ^10.5.0
   languageName: unknown
   linkType: soft
 
-"@metamask/eslint-config-nodejs@workspace:^, @metamask/eslint-config-nodejs@workspace:packages/nodejs":
+"@metamask/eslint-config-nodejs@npm:^13.0.0, @metamask/eslint-config-nodejs@workspace:packages/nodejs":
   version: 0.0.0-use.local
   resolution: "@metamask/eslint-config-nodejs@workspace:packages/nodejs"
   dependencies:
     "@eslint/js": "npm:^9.11.0"
     "@jest/globals": "npm:^29.7.0"
     "@metamask/auto-changelog": "npm:^3.4.4"
-    "@metamask/eslint-config": "workspace:^"
+    "@metamask/eslint-config": "npm:^13.0.0"
     eslint: "npm:^9.11.0"
     eslint-config-prettier: "npm:^9.1.0"
     eslint-plugin-import-x: "npm:^4.3.0"
@@ -1222,7 +1222,7 @@ __metadata:
     prettier: "npm:^3.3.3"
     vitest: "npm:^2.1.1"
   peerDependencies:
-    "@metamask/eslint-config": "workspace:^"
+    "@metamask/eslint-config": ^13.0.0
     eslint: ^9.11.0
     eslint-plugin-n: ^17.10.3
   languageName: unknown
@@ -1237,8 +1237,8 @@ __metadata:
     "@lavamoat/allow-scripts": "npm:^3.0.4"
     "@metamask/auto-changelog": "npm:^3.4.4"
     "@metamask/create-release-branch": "npm:^4.0.0"
-    "@metamask/eslint-config": "workspace:^"
-    "@metamask/eslint-config-nodejs": "workspace:^"
+    "@metamask/eslint-config": "npm:^13.0.0"
+    "@metamask/eslint-config-nodejs": "npm:^13.0.0"
     "@metamask/eslint-config-typescript": "workspace:^"
     "@metamask/eslint-config-vitest": "workspace:^"
     "@metamask/utils": "npm:^9.1.0"
@@ -1269,7 +1269,7 @@ __metadata:
     "@eslint/js": "npm:^9.11.0"
     "@jest/globals": "npm:^29.7.0"
     "@metamask/auto-changelog": "npm:^3.4.4"
-    "@metamask/eslint-config": "workspace:^"
+    "@metamask/eslint-config": "npm:^13.0.0"
     eslint: "npm:^9.11.0"
     eslint-config-prettier: "npm:^9.1.0"
     eslint-import-resolver-typescript: "npm:^3.6.3"
@@ -1282,7 +1282,7 @@ __metadata:
     typescript-eslint: "npm:^8.6.0"
     vitest: "npm:^2.1.1"
   peerDependencies:
-    "@metamask/eslint-config": "workspace:^"
+    "@metamask/eslint-config": ^13.0.0
     eslint: ^9.11.0
     eslint-import-resolver-typescript: ^3.6.3
     eslint-plugin-import-x: ^4.3.0
@@ -1299,7 +1299,7 @@ __metadata:
     "@eslint/js": "npm:^9.11.0"
     "@jest/globals": "npm:^29.7.0"
     "@metamask/auto-changelog": "npm:^3.4.4"
-    "@metamask/eslint-config": "workspace:^"
+    "@metamask/eslint-config": "npm:^13.0.0"
     "@vitest/eslint-plugin": "npm:^1.1.4"
     eslint: "npm:^9.11.0"
     eslint-config-prettier: "npm:^9.1.0"
@@ -1311,13 +1311,13 @@ __metadata:
     prettier: "npm:^3.3.3"
     vitest: "npm:^2.1.1"
   peerDependencies:
-    "@metamask/eslint-config": "workspace:^"
+    "@metamask/eslint-config": ^13.0.0
     "@vitest/eslint-plugin": ^1.1.4
     eslint: ^9.11.0
   languageName: unknown
   linkType: soft
 
-"@metamask/eslint-config@workspace:^, @metamask/eslint-config@workspace:packages/base":
+"@metamask/eslint-config@npm:^13.0.0, @metamask/eslint-config@workspace:packages/base":
   version: 0.0.0-use.local
   resolution: "@metamask/eslint-config@workspace:packages/base"
   dependencies:
@@ -5552,7 +5552,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pony-cause@npm:^2.1.10, pony-cause@npm:^2.1.9":
+"pony-cause@npm:^2.1.10":
+  version: 2.1.10
+  resolution: "pony-cause@npm:2.1.10"
+  checksum: 10/906563565030996d0c40ba79a584e2f298391931acc59c98510f9fd583d72cd9e9c58b0fb5a25bbae19daf16840f94cb9c1ee72c7ed5ef249ecba147cee40495
+  languageName: node
+  linkType: hard
+
+"pony-cause@npm:^2.1.9":
   version: 2.1.11
   resolution: "pony-cause@npm:2.1.11"
   checksum: 10/ed7d0bb6e3e69f753080bf736b71f40e6ae4c13ec0c8c473ff73345345c088819966fdd68a62ad7482d464bf41176cf9421f5f63715d1a4532005eedc099db55
@@ -5951,7 +5958,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"signal-exit@npm:^4.0.1, signal-exit@npm:^4.1.0":
+"signal-exit@npm:^4.0.1":
+  version: 4.0.2
+  resolution: "signal-exit@npm:4.0.2"
+  checksum: 10/99d49eab7f24aeed79e44999500d5ff4b9fbb560b0e1f8d47096c54d625b995aeaec3032cce44527adf2de0c303731a8356e234a348d6801214a8a3385a1ff8e
+  languageName: node
+  linkType: hard
+
+"signal-exit@npm:^4.1.0":
   version: 4.1.0
   resolution: "signal-exit@npm:4.1.0"
   checksum: 10/c9fa63bbbd7431066174a48ba2dd9986dfd930c3a8b59de9c29d7b6854ec1c12a80d15310869ea5166d413b99f041bfa3dd80a7947bcd44ea8e6eb3ffeabfa1f


### PR DESCRIPTION
This reverts commit 597ecb60fc6332d3ebb1f99653f7905256b37ac0.

The release failed because the workflow assumes a `build` script exists, but we don't build anything in this repo. Will fix this in a separate PR.