### PR TITLE
feat(typescript): Update type import specifier rules

### DIFF
--- a/packages/typescript/rules-snapshot.json
+++ b/packages/typescript/rules-snapshot.json
@@ -5,7 +5,6 @@
   "@typescript-eslint/consistent-type-assertions": "error",
   "@typescript-eslint/consistent-type-definitions": ["error", "type"],
   "@typescript-eslint/consistent-type-exports": "error",
-  "@typescript-eslint/consistent-type-imports": "error",
   "@typescript-eslint/default-param-last": "error",
   "@typescript-eslint/explicit-function-return-type": "error",
   "@typescript-eslint/naming-convention": [
@@ -144,6 +143,7 @@
   "constructor-super": "off",
   "default-param-last": "off",
   "getter-return": "off",
+  "import-x/consistent-type-specifier-style": ["error", "prefer-top-level"],
   "import-x/named": "off",
   "import-x/no-unresolved": "off",
   "jsdoc/check-access": "error",

--- a/packages/typescript/src/index.mjs
+++ b/packages/typescript/src/index.mjs
@@ -38,14 +38,10 @@ const config = createConfig({
   },
 
   rules: {
-    // Handled by TypeScript
-    'import-x/no-unresolved': 'off',
-
     // Our rules
     '@typescript-eslint/array-type': 'error',
     '@typescript-eslint/consistent-type-assertions': 'error',
     '@typescript-eslint/consistent-type-definitions': ['error', 'type'],
-    '@typescript-eslint/consistent-type-imports': 'error',
     '@typescript-eslint/explicit-function-return-type': 'error',
     '@typescript-eslint/no-explicit-any': 'off',
     '@typescript-eslint/no-namespace': [
@@ -184,6 +180,15 @@ const config = createConfig({
 
     'no-useless-constructor': 'off',
     '@typescript-eslint/no-useless-constructor': 'error',
+
+    /* import-x plugin rules */
+
+    // Handled by TypeScript
+    'import-x/no-unresolved': 'off',
+
+    // Combined with the "verbatimModuleSyntax" tsconfig option, a better option than
+    // @typescript-eslint/consistent-type-imports
+    'import-x/consistent-type-specifier-style': ['error', 'prefer-top-level'],
 
     /* jsdoc plugin rules */
 

--- a/packages/typescript/tsconfig.json
+++ b/packages/typescript/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
-    "strictNullChecks": true
+    "strictNullChecks": true,
+    "verbatimModuleSyntax": true
   },
   "include": ["src"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,8 @@
     "noUncheckedIndexedAccess": true,
     "resolveJsonModule": true,
     "strict": true,
-    "target": "ES2022"
+    "target": "ES2022",
+    "verbatimModuleSyntax": true
   },
   "include": ["**/*.mjs", "**/*.mts"],
   "exclude": ["./dist", "**/node_modules"]


### PR DESCRIPTION
Ref: https://github.com/MetaMask/ocap-kernel/pull/175

This replaces `@typescript-eslint/consistent-type-imports` with `import-x/consistent-type-specifier-style`, and an exhortation to enable `verbatimModuleSyntax` (requires TypeScript >=5) in the tsconfigs of our packages.

Heretofore, we have enforced the existence of type import specifiers, but not that they are stylistically consistent. The options are:
- "top-level", e.g. `import type { a } from 'x'}`
- "inline", e.g. `import { type a } from 'x'}`
 
The rule `@typescript-eslint/consistent-type-imports` has been responsible for this. This rule has an option named `fixTypes`, but that only applies when a type-only import is _not_ specified as a type-only import. In other words, it enforces the existence of type import specifiers, but not that they're stylistically consistent.

Rather than using `@typescript-eslint/consistent-type-imports` and its confusingly named options, we are better off enabling `verbatimModuleSyntax` in our `tsconfig` files, and enabling `import-x/consistent-type-specifier-style`. In this way, the existence of type import specifiers is enforced by `tsc`, and the `import-x` ESLint plugins ensures that they are consistent. We use the "top-level" style because that results in `import type { a } from 'x';` being elided completely from the JS output as opposed to `import { type a } from 'x';` which would be emitted as `import {} from 'x';`. I don't know if that's actually harmful, but it seems surprising, and I don't like surprises.

Supporting documentation:
- `@typescript-eslint/consistent-type-imports` [rule documentation](https://typescript-eslint.io/rules/consistent-type-imports/#comparison-with-importsnotusedasvalues--verbatimmodulesyntax)
- [The `verbatimModuleSyntax` docs](https://www.typescriptlang.org/tsconfig/#verbatimModuleSyntax)
- This tseslint issue: https://github.com/typescript-eslint/typescript-eslint/issues/9652