### PR TITLE
Remove jest/no-conditional-in-test rule

### DIFF
--- a/packages/jest/rules-snapshot.json
+++ b/packages/jest/rules-snapshot.json
@@ -4,7 +4,6 @@
   "jest/no-alias-methods": "warn",
   "jest/no-commented-out-tests": "warn",
   "jest/no-conditional-expect": "error",
-  "jest/no-conditional-in-test": "error",
   "jest/no-deprecated-functions": "error",
   "jest/no-disabled-tests": "warn",
   "jest/no-done-callback": "error",

--- a/packages/jest/src/index.mjs
+++ b/packages/jest/src/index.mjs
@@ -19,7 +19,6 @@ const config = createConfig({
   rules: {
     'jest/consistent-test-it': ['error', { fn: 'it' }],
     'jest/no-duplicate-hooks': 'error',
-    'jest/no-conditional-in-test': 'error',
     'jest/no-test-return-statement': 'error',
     'jest/prefer-hooks-on-top': 'error',
     'jest/prefer-lowercase-title': ['error', { ignore: ['describe'] }],


### PR DESCRIPTION
I propose that we remove this rule. I would argue that adding logic to tests is not as harmful as the docs for this rule would indicate and in fact can be quite useful.

- When mocking functions with overloads, it is necessary to add logic inside of the mock implementation to handle different arguments.
- When testing a function that can be called multiple ways where the behavior is mostly the same between inputs aside from a few edge cases, using an `if` statement to highlight the difference can be useful.