### PR TITLE
Loosen `promise/catch-or-return` and `promise/param-names` rules

### DIFF
--- a/packages/base/rules-snapshot.json
+++ b/packages/base/rules-snapshot.json
@@ -3248,7 +3248,7 @@
   ],
   "promise/always-return": "error",
   "promise/avoid-new": "off",
-  "promise/catch-or-return": "error",
+  "promise/catch-or-return": ["error", { "allowFinally": true }],
   "promise/no-callback-in-promise": "warn",
   "promise/no-native": "off",
   "promise/no-nesting": "warn",
@@ -3256,7 +3256,10 @@
   "promise/no-promise-in-callback": "warn",
   "promise/no-return-in-finally": "warn",
   "promise/no-return-wrap": "error",
-  "promise/param-names": "error",
+  "promise/param-names": [
+    "error",
+    { "resolvePattern": "^_?resolve", "rejectPattern": "^_?reject" }
+  ],
   "promise/valid-params": "warn",
   "quote-props": "off",
   "quotes": "off",

--- a/packages/base/src/index.mjs
+++ b/packages/base/src/index.mjs
@@ -417,7 +417,20 @@ const rules = createConfig({
     ],
     'jsdoc/valid-types': 'error',
 
-    // 'promise/no-multiple-resolved': 'error',
+    /* promise plugin rules */
+    'promise/catch-or-return': [
+      'error',
+      {
+        allowFinally: true,
+      },
+    ],
+    'promise/param-names': [
+      'error',
+      {
+        resolvePattern: '^_?resolve',
+        rejectPattern: '^_?reject',
+      },
+    ],
   },
 });
 


### PR DESCRIPTION
`promise/catch-or-return` and `promise/param-names` are too strict by default. This changes the configuration slightly to loosen these rules. The exact reasons are explained in a comment below.