### PR TITLE
Update `jsdoc/check-tag-names` to allow `@property` JSDoc tag

### DIFF
--- a/packages/base/rules-snapshot.json
+++ b/packages/base/rules-snapshot.json
@@ -141,7 +141,7 @@
   "jsdoc/check-param-names": "error",
   "jsdoc/check-property-names": "error",
   "jsdoc/check-syntax": "off",
-  "jsdoc/check-tag-names": "error",
+  "jsdoc/check-tag-names": ["error", { "definedTags": ["property"] }],
   "jsdoc/check-template-names": "off",
   "jsdoc/check-types": "error",
   "jsdoc/check-values": "error",

--- a/packages/base/src/index.mjs
+++ b/packages/base/src/index.mjs
@@ -373,7 +373,12 @@ const rules = createConfig({
     'jsdoc/check-line-alignment': 'error',
     'jsdoc/check-param-names': 'error',
     'jsdoc/check-property-names': 'error',
-    'jsdoc/check-tag-names': 'error',
+    'jsdoc/check-tag-names': [
+      'error',
+      {
+        definedTags: ['property'],
+      },
+    ],
     'jsdoc/check-types': 'error',
     'jsdoc/check-values': 'error',
     'jsdoc/empty-tags': 'error',


### PR DESCRIPTION
[`jsdoc/check-tag-names`](https://github.com/gajus/eslint-plugin-jsdoc/blob/e9a98a3c0de9abf6860513b28cf1220891785c5c/.README/rules/check-tag-names.md) by default does not allow `@property` in a typed system (such as TypeScript). This makes sense in places where it's possible to document a property directly, for example:

```ts
type SomeObject = {
  /**
   * Documentation for the property here.
   */
  someProperty: string;
};
```

This is not always the case however, especially when inferring types from structs for example, in which case we use something like this:

```ts
const SomeObjectStruct = object({
  someProperty: string(),
});

/**
 * Some object.
 *
 * @property someProperty - Documentation for the property here.
 */
type SomeObject = Infer<typeof SomeObjectStruct>;
```

For this reason I've updated `jsdoc/check-tag-names` to allow `@property` in TypeScript as well.