### PR TITLE
Disable `promise/always-return` rule

### DIFF
--- a/packages/base/rules-snapshot.json
+++ b/packages/base/rules-snapshot.json
@@ -3246,7 +3246,7 @@
     },
     { "usePrettierrc": true }
   ],
-  "promise/always-return": "error",
+  "promise/always-return": "off",
   "promise/avoid-new": "off",
   "promise/catch-or-return": ["error", { "allowFinally": true }],
   "promise/no-callback-in-promise": "warn",

--- a/packages/base/src/index.mjs
+++ b/packages/base/src/index.mjs
@@ -418,6 +418,7 @@ const rules = createConfig({
     'jsdoc/valid-types': 'error',
 
     /* promise plugin rules */
+    'promise/always-return': 'off',
     'promise/catch-or-return': [
       'error',
       {


### PR DESCRIPTION
When [`promise/always-return`](https://github.com/eslint-community/eslint-plugin-promise/blob/5da83c4cd1e673b7687a466c58d9972bb433e71c/docs/rules/always-return.md) is enabled, you must always return a value from `.then()`. We sometimes use this for side effects, so I think this rule is too strict.