### PR TITLE
Disable `@typescript-eslint/no-unsafe-enum-comparison` rule

### DIFF
--- a/packages/typescript/rules-snapshot.json
+++ b/packages/typescript/rules-snapshot.json
@@ -95,7 +95,7 @@
   "@typescript-eslint/no-unsafe-assignment": "off",
   "@typescript-eslint/no-unsafe-call": "off",
   "@typescript-eslint/no-unsafe-declaration-merging": "error",
-  "@typescript-eslint/no-unsafe-enum-comparison": "error",
+  "@typescript-eslint/no-unsafe-enum-comparison": "off",
   "@typescript-eslint/no-unsafe-function-type": "error",
   "@typescript-eslint/no-unsafe-member-access": "off",
   "@typescript-eslint/no-unsafe-return": "off",

--- a/packages/typescript/src/index.mjs
+++ b/packages/typescript/src/index.mjs
@@ -79,6 +79,7 @@ const config = createConfig({
     // Recommended rules that we do not want to use
     '@typescript-eslint/no-duplicate-type-constituents': 'off',
     '@typescript-eslint/no-redundant-type-constituents': 'off',
+    '@typescript-eslint/no-unsafe-enum-comparison': 'off',
     '@typescript-eslint/require-await': 'off',
 
     // Our rules that require type information


### PR DESCRIPTION
This disables the `@typescript-eslint/no-unsafe-enum-comparison` rule, which disallows comparing enums to string or number values. For example, the following is not allowed when this rule is enabled:

```ts
enum Foo {
  Bar = 'Bar',
  Baz = 'Baz',
}

const myVariable: string = "Bar";
if (myVariable == Foo.Bar) {
  // ...
}
```

We use this pattern in multiple places, so I think this rule is too strict and we should disable it.