### PR TITLE
Loosen `@typescript-eslint/naming-convention` rule to allow more formats for import names

### DIFF
--- a/packages/typescript/rules-snapshot.json
+++ b/packages/typescript/rules-snapshot.json
@@ -18,6 +18,10 @@
     },
     { "selector": "enumMember", "format": ["PascalCase"] },
     {
+      "selector": "import",
+      "format": ["camelCase", "PascalCase", "snake_case", "UPPER_CASE"]
+    },
+    {
       "selector": "interface",
       "format": ["PascalCase"],
       "custom": { "regex": "^I[A-Z]", "match": false }

--- a/packages/typescript/src/index.mjs
+++ b/packages/typescript/src/index.mjs
@@ -96,6 +96,10 @@ const config = createConfig({
         format: ['PascalCase'],
       },
       {
+        selector: 'import',
+        format: ['camelCase', 'PascalCase', 'snake_case', 'UPPER_CASE'],
+      },
+      {
         selector: 'interface',
         format: ['PascalCase'],
         custom: {


### PR DESCRIPTION
The bump to a more recent version of the TypeScript ESLint plugin added support for specifying naming conventions for import names (`import name from 'package';`). We didn't add a case for this, so the default format of `camelCase` applied, meaning that this is not allowed:

```ts
import SomeClass from 'some-package';
```

I've updated the rule to allow `camelCase`, `PascalCase`, `snake_case`, and `UPPER_CASE`, since the names of imports can depend on the (3rd party) package, and it feels unnecessary to enforce more strict formats in this case.