### PR TITLE
Loosen `@typescript-eslint/prefer-promise-reject-errors` rule to allow rejecting with `unknown`

### DIFF
--- a/packages/typescript/rules-snapshot.json
+++ b/packages/typescript/rules-snapshot.json
@@ -129,7 +129,7 @@
   "@typescript-eslint/prefer-namespace-keyword": "error",
   "@typescript-eslint/prefer-nullish-coalescing": "error",
   "@typescript-eslint/prefer-optional-chain": "error",
-  "@typescript-eslint/prefer-promise-reject-errors": "error",
+  "@typescript-eslint/prefer-promise-reject-errors": "off",
   "@typescript-eslint/prefer-readonly": "error",
   "@typescript-eslint/prefer-reduce-type-parameter": "error",
   "@typescript-eslint/prefer-string-starts-ends-with": "error",

--- a/packages/typescript/rules-snapshot.json
+++ b/packages/typescript/rules-snapshot.json
@@ -129,7 +129,10 @@
   "@typescript-eslint/prefer-namespace-keyword": "error",
   "@typescript-eslint/prefer-nullish-coalescing": "error",
   "@typescript-eslint/prefer-optional-chain": "error",
-  "@typescript-eslint/prefer-promise-reject-errors": "off",
+  "@typescript-eslint/prefer-promise-reject-errors": [
+    "error",
+    { "allowThrowingUnknown": true }
+  ],
   "@typescript-eslint/prefer-readonly": "error",
   "@typescript-eslint/prefer-reduce-type-parameter": "error",
   "@typescript-eslint/prefer-string-starts-ends-with": "error",

--- a/packages/typescript/src/index.mjs
+++ b/packages/typescript/src/index.mjs
@@ -75,6 +75,7 @@ const config = createConfig({
     // Recommended rules that we do not want to use
     '@typescript-eslint/no-duplicate-type-constituents': 'off',
     '@typescript-eslint/no-redundant-type-constituents': 'off',
+    '@typescript-eslint/prefer-promise-reject-errors': 'off',
     '@typescript-eslint/require-await': 'off',
 
     // Our rules that require type information

--- a/packages/typescript/src/index.mjs
+++ b/packages/typescript/src/index.mjs
@@ -75,7 +75,6 @@ const config = createConfig({
     // Recommended rules that we do not want to use
     '@typescript-eslint/no-duplicate-type-constituents': 'off',
     '@typescript-eslint/no-redundant-type-constituents': 'off',
-    '@typescript-eslint/prefer-promise-reject-errors': 'off',
     '@typescript-eslint/require-await': 'off',
 
     // Our rules that require type information
@@ -156,6 +155,10 @@ const config = createConfig({
     '@typescript-eslint/prefer-enum-initializers': 'error',
     '@typescript-eslint/prefer-includes': 'error',
     '@typescript-eslint/prefer-nullish-coalescing': 'error',
+    '@typescript-eslint/prefer-promise-reject-errors': [
+      'error',
+      { allowThrowingUnknown: true },
+    ],
     '@typescript-eslint/prefer-readonly': 'error',
     '@typescript-eslint/prefer-reduce-type-parameter': 'error',
     '@typescript-eslint/prefer-string-starts-ends-with': 'error',


### PR DESCRIPTION
This changes the `@typescript-eslint/prefer-promise-reject-errors` rule, which enforces that `Promise.reject` must be called with an instance of `Error`. After this change, `reject` may also be called with `unknown` values. For example, the following code was previously invalid, but is valid after this change:

```ts
new Promise((resolve, reject) => {
  try {
    return resolve(doSomething());
  } catch (error) {
    // `error` is of type `unknown`.
    return reject(error);
  }
});
```