### PR TITLE
BREAKING: Update `jsdoc/require-jsdoc` to require documentation for more things

### DIFF
--- a/packages/base/rules-snapshot.json
+++ b/packages/base/rules-snapshot.json
@@ -176,7 +176,24 @@
     "always",
     { "tags": { "returns": "never", "template": "always", "throws": "never" } }
   ],
-  "jsdoc/require-jsdoc": "error",
+  "jsdoc/require-jsdoc": [
+    "error",
+    {
+      "require": {
+        "ArrowFunctionExpression": true,
+        "ClassDeclaration": true,
+        "FunctionDeclaration": true,
+        "FunctionExpression": true,
+        "MethodDefinition": true
+      },
+      "contexts": [
+        "TSInterfaceDeclaration",
+        "TSTypeAliasDeclaration",
+        "TSEnumDeclaration",
+        "TSPropertySignature"
+      ]
+    }
+  ],
   "jsdoc/require-param": ["error", { "unnamedRootBase": ["options"] }],
   "jsdoc/require-param-description": "error",
   "jsdoc/require-param-name": "error",

--- a/packages/base/src/index.d.mts
+++ b/packages/base/src/index.d.mts
@@ -11,6 +11,10 @@ declare module '@metamask/eslint-config' {
    * can only be used with the {@link createConfig} function.
    */
   type ConfigWithExtends = Config & {
+    /**
+     * The configuration(s) to extend. This can be a single configuration, an
+     * array of configurations, or an array of arrays of configurations.
+     */
     extends?: Config | Config[] | Config[][];
   };
 

--- a/packages/base/src/index.mjs
+++ b/packages/base/src/index.mjs
@@ -393,7 +393,24 @@ const rules = createConfig({
       'always',
       { tags: { returns: 'never', template: 'always', throws: 'never' } },
     ],
-    'jsdoc/require-jsdoc': 'error',
+    'jsdoc/require-jsdoc': [
+      'error',
+      {
+        require: {
+          ArrowFunctionExpression: true,
+          ClassDeclaration: true,
+          FunctionDeclaration: true,
+          FunctionExpression: true,
+          MethodDefinition: true,
+        },
+        contexts: [
+          'TSInterfaceDeclaration',
+          'TSTypeAliasDeclaration',
+          'TSEnumDeclaration',
+          'TSPropertySignature',
+        ],
+      },
+    ],
     'jsdoc/require-param-name': 'error',
     'jsdoc/require-param': ['error', { unnamedRootBase: ['options'] }],
     'jsdoc/require-param-description': 'error',


### PR DESCRIPTION
This updates the `jsdoc/require-jsdoc` rule to require documentation for:

- Arrow functions.
   ```ts
   const myFunction = () => {
     // ...
   };
   ```

- Class declarations.
   ```ts
   class MyClass {
     // ...
   }
   ```

- TypeScript enum declarations.
   ```ts
   enum MyEnum {
     // ...
   };
   ```

- Function expressions.
   ```ts
   const myFunction = function () {
     // ...
   };
   ```

- TypeScript interface declarations.
   ```ts
   interface MyInterface {
     // ...
   };
   ```

- Method definitions.
   ```ts
   const myObject = {
     myFunction() {
       // ...
     },
   };
   ```

- TypeScript type alias declarations.
   ```ts
   type MyType = {
     // ...
   };

- TypeScript property signatures.
   ```ts
   type MyType = {
     myProperty: string;
   };
   ```

## Breaking changes

Each of the code blocks above was previously valid, but will now produce an error.

Closes #223.