### PR TITLE
Revert "feat(typescript): Update type import specifier rules"

### DIFF
--- a/packages/typescript/rules-snapshot.json
+++ b/packages/typescript/rules-snapshot.json
@@ -5,6 +5,7 @@
   "@typescript-eslint/consistent-type-assertions": "error",
   "@typescript-eslint/consistent-type-definitions": ["error", "type"],
   "@typescript-eslint/consistent-type-exports": "error",
+  "@typescript-eslint/consistent-type-imports": "error",
   "@typescript-eslint/default-param-last": "error",
   "@typescript-eslint/explicit-function-return-type": "error",
   "@typescript-eslint/naming-convention": [
@@ -153,7 +154,6 @@
   "constructor-super": "off",
   "default-param-last": "off",
   "getter-return": "off",
-  "import-x/consistent-type-specifier-style": ["error", "prefer-top-level"],
   "import-x/named": "off",
   "import-x/no-unresolved": "off",
   "jsdoc/check-access": "error",

--- a/packages/typescript/src/index.mjs
+++ b/packages/typescript/src/index.mjs
@@ -38,10 +38,14 @@ const config = createConfig({
   },
 
   rules: {
+    // Handled by TypeScript
+    'import-x/no-unresolved': 'off',
+
     // Our rules
     '@typescript-eslint/array-type': 'error',
     '@typescript-eslint/consistent-type-assertions': 'error',
     '@typescript-eslint/consistent-type-definitions': ['error', 'type'],
+    '@typescript-eslint/consistent-type-imports': 'error',
     '@typescript-eslint/explicit-function-return-type': 'error',
     '@typescript-eslint/no-explicit-any': 'off',
     '@typescript-eslint/no-namespace': [
@@ -194,15 +198,6 @@ const config = createConfig({
 
     'no-useless-constructor': 'off',
     '@typescript-eslint/no-useless-constructor': 'error',
-
-    /* import-x plugin rules */
-
-    // Handled by TypeScript
-    'import-x/no-unresolved': 'off',
-
-    // Combined with the "verbatimModuleSyntax" tsconfig option, a better option than
-    // @typescript-eslint/consistent-type-imports
-    'import-x/consistent-type-specifier-style': ['error', 'prefer-top-level'],
 
     /* jsdoc plugin rules */
 

--- a/packages/typescript/tsconfig.json
+++ b/packages/typescript/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
-    "strictNullChecks": true,
-    "verbatimModuleSyntax": true
+    "strictNullChecks": true
   },
   "include": ["src"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,8 +12,7 @@
     "noUncheckedIndexedAccess": true,
     "resolveJsonModule": true,
     "strict": true,
-    "target": "ES2022",
-    "verbatimModuleSyntax": true
+    "target": "ES2022"
   },
   "include": ["**/*.mjs", "**/*.mts"],
   "exclude": ["./dist", "**/node_modules"]


### PR DESCRIPTION
Reverts MetaMask/eslint-config#381 temporarily because it includes breaking changes, and we'd like to release the non-breaking changes on `main` without a major version bump. This will be restored after release.