### PR TITLE
Revert "Revert "feat(typescript): Update type import specifier rules""

### DIFF
--- a/packages/typescript/rules-snapshot.json
+++ b/packages/typescript/rules-snapshot.json
@@ -5,7 +5,6 @@
   "@typescript-eslint/consistent-type-assertions": "error",
   "@typescript-eslint/consistent-type-definitions": ["error", "type"],
   "@typescript-eslint/consistent-type-exports": "error",
-  "@typescript-eslint/consistent-type-imports": "error",
   "@typescript-eslint/default-param-last": "error",
   "@typescript-eslint/explicit-function-return-type": "error",
   "@typescript-eslint/naming-convention": [
@@ -154,6 +153,7 @@
   "constructor-super": "off",
   "default-param-last": "off",
   "getter-return": "off",
+  "import-x/consistent-type-specifier-style": ["error", "prefer-top-level"],
   "import-x/named": "off",
   "import-x/no-unresolved": "off",
   "jsdoc/check-access": "error",

--- a/packages/typescript/src/index.mjs
+++ b/packages/typescript/src/index.mjs
@@ -38,14 +38,10 @@ const config = createConfig({
   },
 
   rules: {
-    // Handled by TypeScript
-    'import-x/no-unresolved': 'off',
-
     // Our rules
     '@typescript-eslint/array-type': 'error',
     '@typescript-eslint/consistent-type-assertions': 'error',
     '@typescript-eslint/consistent-type-definitions': ['error', 'type'],
-    '@typescript-eslint/consistent-type-imports': 'error',
     '@typescript-eslint/explicit-function-return-type': 'error',
     '@typescript-eslint/no-explicit-any': 'off',
     '@typescript-eslint/no-namespace': [
@@ -198,6 +194,15 @@ const config = createConfig({
 
     'no-useless-constructor': 'off',
     '@typescript-eslint/no-useless-constructor': 'error',
+
+    /* import-x plugin rules */
+
+    // Handled by TypeScript
+    'import-x/no-unresolved': 'off',
+
+    // Combined with the "verbatimModuleSyntax" tsconfig option, a better option than
+    // @typescript-eslint/consistent-type-imports
+    'import-x/consistent-type-specifier-style': ['error', 'prefer-top-level'],
 
     /* jsdoc plugin rules */
 

--- a/packages/typescript/tsconfig.json
+++ b/packages/typescript/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
-    "strictNullChecks": true
+    "strictNullChecks": true,
+    "verbatimModuleSyntax": true
   },
   "include": ["src"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,8 @@
     "noUncheckedIndexedAccess": true,
     "resolveJsonModule": true,
     "strict": true,
-    "target": "ES2022"
+    "target": "ES2022",
+    "verbatimModuleSyntax": true
   },
   "include": ["**/*.mjs", "**/*.mts"],
   "exclude": ["./dist", "**/node_modules"]


### PR DESCRIPTION
Reverts MetaMask/eslint-config#407, which itself was a revert of https://github.com/MetaMask/eslint-config/pull/381 because it had breaking changes, and we wanted to release some non-breaking things first.

This PR restores the breaking changes in #381.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace @typescript-eslint/consistent-type-imports with import-x/consistent-type-specifier-style (prefer-top-level) and enable TypeScript verbatimModuleSyntax in tsconfigs.
> 
> - **TypeScript ESLint config (`packages/typescript/src/index.mjs`, `rules-snapshot.json`)**:
>   - Add `import-x/consistent-type-specifier-style: ["error", "prefer-top-level"]` and keep `import-x/no-unresolved: "off"`.
>   - Remove `@typescript-eslint/consistent-type-imports`.
> - **TypeScript config (`tsconfig.json`, `packages/typescript/tsconfig.json`)**:
>   - Enable `compilerOptions.verbatimModuleSyntax: true`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 245508bcd10fcab51aea46e2c2128f5453f95188. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->