### PR TITLE
Revert "Release/14.1.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/eslint-config-root",
-  "version": "14.1.0",
+  "version": "14.0.0",
   "private": true,
   "repository": {
     "type": "git",

--- a/packages/base/CHANGELOG.md
+++ b/packages/base/CHANGELOG.md
@@ -7,12 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [14.1.0]
-
-### Changed
-
-- Loosen `promise/catch-or-return` and `promise/param-names` rules ([#384](https://github.com/MetaMask/eslint-config/pull/384))
-
 ## [14.0.0]
 
 ### Changed
@@ -270,8 +264,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add base, TypeScript, and Jest configs (#3)
 
-[Unreleased]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config@14.1.0...HEAD
-[14.1.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config@14.0.0...@metamask/eslint-config@14.1.0
+[Unreleased]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config@14.0.0...HEAD
 [14.0.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config@13.0.0...@metamask/eslint-config@14.0.0
 [13.0.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config@12.2.0...@metamask/eslint-config@13.0.0
 [12.2.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config@12.1.0...@metamask/eslint-config@12.2.0

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/eslint-config",
-  "version": "14.1.0",
+  "version": "14.0.0",
   "description": "Shareable MetaMask ESLint config.",
   "homepage": "https://github.com/MetaMask/eslint-config#readme",
   "bugs": {

--- a/packages/jest/CHANGELOG.md
+++ b/packages/jest/CHANGELOG.md
@@ -7,14 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [14.1.0]
-
-### Changed
-
-- Replace `@typescript-eslint/unbound-method` rule with `jest/unbound-method` in Jest tests ([#391](https://github.com/MetaMask/eslint-config/pull/391))
-  - `jest/unbound-method` is looser than `@typescript-eslint/unbound-method`, so this should be a non-breaking change unless `@typescript-eslint/unbound-method` is disabled.
-- Remove `jest/no-conditional-in-test` rule ([#383](https://github.com/MetaMask/eslint-config/pull/383))
-
 ## [14.0.0]
 
 ### Changed
@@ -115,8 +107,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - To continue extending this config, install this package and update your `.eslintrc.js` `extends` array to include `@metamask/eslint-config-jest` instead of `@metamask/eslint-config/jest`.
 - Update `eslint` and other ESLint peer dependencies ([#151](https://github.com/MetaMask/eslint-config/pull/151))
 
-[Unreleased]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-jest@14.1.0...HEAD
-[14.1.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-jest@14.0.0...@metamask/eslint-config-jest@14.1.0
+[Unreleased]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-jest@14.0.0...HEAD
 [14.0.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-jest@13.0.0...@metamask/eslint-config-jest@14.0.0
 [13.0.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-jest@12.1.0...@metamask/eslint-config-jest@13.0.0
 [12.1.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-jest@12.0.0...@metamask/eslint-config-jest@12.1.0

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/eslint-config-jest",
-  "version": "14.1.0",
+  "version": "14.0.0",
   "description": "Shareable MetaMask ESLint config for Jest.",
   "homepage": "https://github.com/MetaMask/eslint-config#readme",
   "bugs": {

--- a/packages/typescript/CHANGELOG.md
+++ b/packages/typescript/CHANGELOG.md
@@ -7,19 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [14.1.0]
-
-### Added
-
-- Add support for TypeScript 5.6.x-5.8.x ([#395](https://github.com/MetaMask/eslint-config/pull/395))
-
-### Changed
-
-- Disable `@typescript-eslint/no-unsafe-enum-comparison` rule ([#387](https://github.com/MetaMask/eslint-config/pull/387))
-- Loosen `@typescript-eslint/prefer-promise-reject-errors` rule to allow rejecting with `unknown` ([#389](https://github.com/MetaMask/eslint-config/pull/389))
-- Loosen `@typescript-eslint/naming-convention` rule to allow more formats for import names ([#388](https://github.com/MetaMask/eslint-config/pull/388))
-- Loosen `@typescript-eslint/switch-exhaustiveness-check` rule to allow `default` case ([#390](https://github.com/MetaMask/eslint-config/pull/390))
-
 ## [14.0.0]
 
 ### Added
@@ -184,8 +171,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - To continue extending this config, install this package and update your `.eslintrc.js` `extends` array to include `@metamask/eslint-config-typescript` instead of `@metamask/eslint-config/typescript`.
 - Update `eslint` and other ESLint peer dependencies ([#151](https://github.com/MetaMask/eslint-config/pull/151))
 
-[Unreleased]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-typescript@14.1.0...HEAD
-[14.1.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-typescript@14.0.0...@metamask/eslint-config-typescript@14.1.0
+[Unreleased]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-typescript@14.0.0...HEAD
 [14.0.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-typescript@13.0.0...@metamask/eslint-config-typescript@14.0.0
 [13.0.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-typescript@12.1.0...@metamask/eslint-config-typescript@13.0.0
 [12.1.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-typescript@12.0.0...@metamask/eslint-config-typescript@12.1.0

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/eslint-config-typescript",
-  "version": "14.1.0",
+  "version": "14.0.0",
   "description": "Shareable MetaMask ESLint config for TypeScript.",
   "homepage": "https://github.com/MetaMask/eslint-config#readme",
   "bugs": {


### PR DESCRIPTION
Reverts MetaMask/eslint-config#411, which had a publishing failure. We will re-attempt after fixing the issue.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reverts the 14.1.0 release by downgrading versions to 14.0.0 and removing 14.1.0 entries from changelogs.
> 
> - **Versions**:
>   - Set `version` back to `14.0.0` in `package.json`, `packages/base/package.json`, `packages/jest/package.json`, and `packages/typescript/package.json`.
> - **Changelogs**:
>   - Remove `14.1.0` sections and update `[Unreleased]` comparison links in `packages/base/CHANGELOG.md`, `packages/jest/CHANGELOG.md`, and `packages/typescript/CHANGELOG.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 862268ae28522c4903a28e32473416cefbb8d10f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->