### PR TITLE
ci: Fix publish workflow

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -21,7 +21,6 @@ jobs:
       - uses: MetaMask/action-publish-release@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - run: yarn build
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
The publishing workflow attempted to run a `yarn build` script that does not exist.

In this repository, the `src` directory of each package is published directly with no build step. The publish workflow was fixed by removing the invalid build command.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the nonexistent `yarn build` step from `.github/workflows/publish-release.yml`, leaving artifact upload of package `src` files intact.
> 
> - **CI / GitHub Actions**
>   - `/.github/workflows/publish-release.yml`:
>     - Remove `run: yarn build` step from `publish-release` job.
>     - Continue uploading `./packages/**/src` and `.yarn-state.yml` as artifacts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4d572ab746ce8fee390065eb05ec3cff3c19621e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->