### PR TITLE
chore: Increase minimum `typescript-eslint` version

### DIFF
--- a/packages/typescript/CHANGELOG.md
+++ b/packages/typescript/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING:** Update `typescript-eslint` peer dependency to have a minimum version of v8.39.0 ([#423](https://github.com/MetaMask/eslint-config/pull/423))
+  - This version has a matching supported `typescript` range, and includes some bug fixes for problems we ran into.
+
 ## [14.1.0]
 
 ### Added

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -59,7 +59,7 @@
     "eslint-plugin-import-x": "^4.3.0",
     "eslint-plugin-jsdoc": "^50.2.4",
     "typescript": ">=4.8.4 <6",
-    "typescript-eslint": "^8.24"
+    "typescript-eslint": "^8.39.0"
   },
   "engines": {
     "node": "^18.18 || >=20"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1278,7 +1278,7 @@ __metadata:
     eslint-plugin-import-x: ^4.3.0
     eslint-plugin-jsdoc: ^50.2.4
     typescript: ">=4.8.4 <6"
-    typescript-eslint: ^8.24
+    typescript-eslint: ^8.39.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
The minimum version of `typescript-eslint` has been updated to v8.39.0. This is the version that included widening the range of allowed `typescript` versions, so this new minimum will ensure users of this config won't see warnings about incompatible typescript versions if they satisfy this new minimum.

This update also brings in a bug fix we encountered on `core` related to the `@typescript-eslint/no-unnecessary-type-assertion` rule, which was in v8.31.0. Details here:
https://github.com/typescript-eslint/typescript-eslint/issues/8721

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Increase `typescript-eslint` peer dependency minimum to ^8.39.0 and document as a breaking change.
> 
> - **TypeScript config package (`packages/typescript`)**:
>   - **Peer deps**: Raise `typescript-eslint` minimum from `^8.24` to `^8.39.0` in `package.json`.
>   - **Changelog**: Add Unreleased entry marking this as a **BREAKING** change with notes on compatibility and fixes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 735688e5c57cdf6796873245627c329a0a4addc7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->