### PR TITLE
feat: Loosen `@typescript-eslint/naming-convention` for object literal properties

### DIFF
--- a/packages/typescript/CHANGELOG.md
+++ b/packages/typescript/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Disable `promise/valid-params` because it's redundant in type-checked projects ([#425](https://github.com/MetaMask/eslint-config/pull/425))
 - Disable `import-x/no-duplicates` ([#427](https://github.com/MetaMask/eslint-config/pull/427))
   - It was a style preference that we may not want, and the auto-fix was broken.
+- Loosen `@typescript-eslint/naming-convention` by not enforcing naming conventions for object literal properties ([#428](https://github.com/MetaMask/eslint-config/pull/428))
+  - Object literals are too often used as parameters for 3rd party libraries/services.
 
 ### Fixed
 

--- a/packages/typescript/rules-snapshot.json
+++ b/packages/typescript/rules-snapshot.json
@@ -29,10 +29,7 @@
       "selector": "objectLiteralMethod",
       "format": ["camelCase", "PascalCase", "UPPER_CASE"]
     },
-    {
-      "selector": "objectLiteralProperty",
-      "format": ["camelCase", "PascalCase", "UPPER_CASE"]
-    },
+    { "selector": "objectLiteralProperty", "format": null },
     { "selector": "typeLike", "format": ["PascalCase"] },
     {
       "selector": "typeParameter",

--- a/packages/typescript/src/index.mjs
+++ b/packages/typescript/src/index.mjs
@@ -113,7 +113,9 @@ const config = createConfig({
       },
       {
         selector: 'objectLiteralProperty',
-        format: ['camelCase', 'PascalCase', 'UPPER_CASE'],
+        // Disabled because object literals are often parameters to 3rd party libraries/services,
+        // which we don't set the naming conventions for
+        format: null,
       },
       {
         selector: 'typeLike',


### PR DESCRIPTION
The rule `@typescript-eslint/naming-convention` has been updated to no longer enforce a naming convention for object literal properties. This too often needs to be disabled because of the naming conventions of 3rd party libraries/services that we don't control, which can require object-literal parameters.

Closes #323

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Stops enforcing naming conventions for `objectLiteralProperty` in the TypeScript ESLint config; updates snapshot and changelog accordingly.
> 
> - **TypeScript ESLint config (`packages/typescript/src/index.mjs`)**:
>   - Loosen `@typescript-eslint/naming-convention` by setting `objectLiteralProperty` `format: null` (with comment explaining third-party params).
> - **Rules snapshot (`packages/typescript/rules-snapshot.json`)**:
>   - Reflect the `objectLiteralProperty` change to `format: null`.
> - **Changelog (`packages/typescript/CHANGELOG.md`)**:
>   - Add entry noting the loosened naming convention for object literal properties.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2e72fb72735542f790a296df3c80f0cb538bc561. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->