### PR TITLE
fix: Disable `jsdoc/check-indentation` to fix bullet list formatting

### DIFF
--- a/packages/typescript/CHANGELOG.md
+++ b/packages/typescript/CHANGELOG.md
@@ -18,11 +18,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - It was a style preference that we may not want, and the auto-fix was broken.
 - Loosen `@typescript-eslint/naming-convention` by not enforcing naming conventions for object literal properties ([#428](https://github.com/MetaMask/eslint-config/pull/428))
   - Object literals are too often used as parameters for 3rd party libraries/services.
+- Disable `jsdoc/check-indentation` ([#430](https://github.com/MetaMask/eslint-config/pull/430))
+  - Disabled due to a problem with indended sections in TSDoc blocks.
 
 ### Fixed
 
 - Prevent non-type imports from being grouped under a type import upon auto-fix ([#427](https://github.com/MetaMask/eslint-config/pull/427))
   - This was caused by `import-x/no-duplicates`, which is now disabled.
+- Fix false positive lint error on TSDoc blocks with indended sections (e.g. bullet lists) ([#430](https://github.com/MetaMask/eslint-config/pull/430))
 
 ## [14.1.0]
 

--- a/packages/typescript/rules-snapshot.json
+++ b/packages/typescript/rules-snapshot.json
@@ -157,7 +157,7 @@
   "jsdoc/check-access": "error",
   "jsdoc/check-alignment": "error",
   "jsdoc/check-examples": "off",
-  "jsdoc/check-indentation": "error",
+  "jsdoc/check-indentation": "off",
   "jsdoc/check-line-alignment": "off",
   "jsdoc/check-param-names": "error",
   "jsdoc/check-property-names": "error",

--- a/packages/typescript/src/index.mjs
+++ b/packages/typescript/src/index.mjs
@@ -217,9 +217,10 @@ const config = createConfig({
 
     'jsdoc/check-syntax': 'error',
 
-    // This is enabled here rather than in the base config because it doesn't play nicely with
-    // multi-line JSDoc types.
-    'jsdoc/check-indentation': 'error',
+    // This is disabled because it doesn't work with bullet lists, and other types of indented
+    // sections. This issue is fixed in later versions, we can re-enable it after updating.
+    // See https://github.com/gajus/eslint-plugin-jsdoc/issues/541 for details
+    'jsdoc/check-indentation': 'off',
 
     // Use TypeScript types rather than JSDoc types.
     'jsdoc/no-types': 'error',


### PR DESCRIPTION
Bulleted lists and other types of indented sections are incorrectly flagged by the current version of the `jsdoc/check-indentation` rule, so it has been temporarily disabled.

We can bring it back in a later version after updating the plugin to 61.4, which includes a new option that can fix this problem. That has been postponed for now because it requires bumping the minimum supported Node.js version.

Fixes #404

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Turns off `jsdoc/check-indentation` in the TypeScript ESLint config and updates the changelog and rule snapshot accordingly.
> 
> - **TypeScript ESLint config (`packages/typescript/src/index.mjs`)**:
>   - Disable `jsdoc/check-indentation` (`'off'`) with notes about issues on indented sections/bullet lists.
> - **Rules snapshot (`packages/typescript/rules-snapshot.json`)**:
>   - Update `jsdoc/check-indentation` from `"error"` to `"off"`.
> - **Changelog (`packages/typescript/CHANGELOG.md`)**:
>   - Add entry under Changed to disable `jsdoc/check-indentation`.
>   - Add entry under Fixed noting false positives on TSDoc blocks with indented sections.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9ee5744e331cda060b114cfa19dc0bb3a06242d4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->