### PR TITLE
Release/15.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/eslint-config-root",
-  "version": "14.1.0",
+  "version": "15.0.0",
   "private": true,
   "repository": {
     "type": "git",

--- a/packages/base/CHANGELOG.md
+++ b/packages/base/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [15.0.0]
+
 ### Uncategorized
 
 - BREAKING: Update `jsdoc/require-jsdoc` to require documentation for more things ([#394](https://github.com/MetaMask/eslint-config/pull/394))
@@ -284,7 +286,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add base, TypeScript, and Jest configs (#3)
 
-[Unreleased]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config@14.1.0...HEAD
+[Unreleased]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config@15.0.0...HEAD
+[15.0.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config@14.1.0...@metamask/eslint-config@15.0.0
 [14.1.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config@14.0.0...@metamask/eslint-config@14.1.0
 [14.0.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config@13.0.0...@metamask/eslint-config@14.0.0
 [13.0.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config@12.2.0...@metamask/eslint-config@13.0.0

--- a/packages/base/CHANGELOG.md
+++ b/packages/base/CHANGELOG.md
@@ -9,12 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [15.0.0]
 
-### Uncategorized
-
-- BREAKING: Update `jsdoc/require-jsdoc` to require documentation for more things ([#394](https://github.com/MetaMask/eslint-config/pull/394))
-
 ### Changed
 
+- **BREAKING:** Update `jsdoc/require-jsdoc` to require documentation for more things ([#394](https://github.com/MetaMask/eslint-config/pull/394))
+  - New things that now require documentation are:
+    - Arrow functions
+    - Class declarations
+    - TypeScript enum declarations
+    - Function expressions
+    - TypeScript interface declarations
+    - Method definitions
+    - TypeScript type alias declarations
+    - TypeScript property signatures
 - **BREAKING:** Convert various rules from `warn` to `error` ([#424](https://github.com/MetaMask/eslint-config/pull/424))
   - The rules impacted are:
     - `promise/no-callback-in-promise`

--- a/packages/base/CHANGELOG.md
+++ b/packages/base/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- BREAKING: Update `jsdoc/require-jsdoc` to require documentation for more things ([#394](https://github.com/MetaMask/eslint-config/pull/394))
+
 ### Changed
 
 - **BREAKING:** Convert various rules from `warn` to `error` ([#424](https://github.com/MetaMask/eslint-config/pull/424))

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/eslint-config",
-  "version": "14.1.0",
+  "version": "15.0.0",
   "description": "Shareable MetaMask ESLint config.",
   "homepage": "https://github.com/MetaMask/eslint-config#readme",
   "bugs": {

--- a/packages/browser/CHANGELOG.md
+++ b/packages/browser/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- Bump vite and vitest to address security vulns ([#393](https://github.com/MetaMask/eslint-config/pull/393))
+
 ## [14.0.0]
 
 ### Changed

--- a/packages/browser/CHANGELOG.md
+++ b/packages/browser/CHANGELOG.md
@@ -9,9 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [15.0.0]
 
-### Uncategorized
+### Changed
 
-- Bump vite and vitest to address security vulns ([#393](https://github.com/MetaMask/eslint-config/pull/393))
+- **BREAKING:** Bump peer dependency on `@metamask/eslint-config` from `^14.0.0` to `^15.0.0` ([#431](https://github.com/MetaMask/eslint-config/pull/431))
 
 ## [14.0.0]
 

--- a/packages/browser/CHANGELOG.md
+++ b/packages/browser/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [15.0.0]
+
 ### Uncategorized
 
 - Bump vite and vitest to address security vulns ([#393](https://github.com/MetaMask/eslint-config/pull/393))
@@ -58,7 +60,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release of this package.
 
-[Unreleased]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-browser@14.0.0...HEAD
+[Unreleased]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-browser@15.0.0...HEAD
+[15.0.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-browser@14.0.0...@metamask/eslint-config-browser@15.0.0
 [14.0.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-browser@13.0.0...@metamask/eslint-config-browser@14.0.0
 [13.0.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-browser@12.1.0...@metamask/eslint-config-browser@13.0.0
 [12.1.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-browser@12.0.0...@metamask/eslint-config-browser@12.1.0

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/eslint-config-browser",
-  "version": "14.0.0",
+  "version": "15.0.0",
   "description": "Shareable MetaMask ESLint plugin for browser environments.",
   "homepage": "https://github.com/MetaMask/eslint-config#readme",
   "bugs": {

--- a/packages/commonjs/CHANGELOG.md
+++ b/packages/commonjs/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- Bump vite and vitest to address security vulns ([#393](https://github.com/MetaMask/eslint-config/pull/393))
+
 ## [14.0.0]
 
 ### Changed

--- a/packages/commonjs/CHANGELOG.md
+++ b/packages/commonjs/CHANGELOG.md
@@ -9,9 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [15.0.0]
 
-### Uncategorized
+### Changed
 
-- Bump vite and vitest to address security vulns ([#393](https://github.com/MetaMask/eslint-config/pull/393))
+- **BREAKING:** Bump peer dependency on `@metamask/eslint-config` from `^14.0.0` to `^15.0.0` ([#431](https://github.com/MetaMask/eslint-config/pull/431))
 
 ## [14.0.0]
 

--- a/packages/commonjs/CHANGELOG.md
+++ b/packages/commonjs/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [15.0.0]
+
 ### Uncategorized
 
 - Bump vite and vitest to address security vulns ([#393](https://github.com/MetaMask/eslint-config/pull/393))
@@ -53,7 +55,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release of this package ([#267](https://github.com/MetaMask/eslint-config/pull/267))
 
-[Unreleased]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-commonjs@14.0.0...HEAD
+[Unreleased]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-commonjs@15.0.0...HEAD
+[15.0.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-commonjs@14.0.0...@metamask/eslint-config-commonjs@15.0.0
 [14.0.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-commonjs@13.0.0...@metamask/eslint-config-commonjs@14.0.0
 [13.0.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-commonjs@12.1.0...@metamask/eslint-config-commonjs@13.0.0
 [12.1.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-commonjs@12.0.0...@metamask/eslint-config-commonjs@12.1.0

--- a/packages/commonjs/package.json
+++ b/packages/commonjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/eslint-config-commonjs",
-  "version": "14.0.0",
+  "version": "15.0.0",
   "description": "Shareable MetaMask ESLint config for CommonJS projects.",
   "homepage": "https://github.com/MetaMask/eslint-config#readme",
   "bugs": {

--- a/packages/jest/CHANGELOG.md
+++ b/packages/jest/CHANGELOG.md
@@ -9,18 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [15.0.0]
 
-### Uncategorized
-
-- Allow remaining TypeScript 5.x versions ([#422](https://github.com/MetaMask/eslint-config/pull/422))
-
 ### Changed
 
+- **BREAKING:** Bump peer dependency on `@metamask/eslint-config` from `^14.0.0` to `^15.0.0` ([#431](https://github.com/MetaMask/eslint-config/pull/431))
 - **BREAKING:** Convert various rules from `warn` to `error` ([#424](https://github.com/MetaMask/eslint-config/pull/424))
   - The rules impacted are:
     - `jest/expect-expect`
     - `jest/no-alias-methods`
     - `jest/no-commented-out-tests`
     - `jest/no-disabled-tests`
+- Widen `typescript` peer dependency to allow all 5.x versions ([#422](https://github.com/MetaMask/eslint-config/pull/422))
 
 ## [14.1.0]
 

--- a/packages/jest/CHANGELOG.md
+++ b/packages/jest/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [15.0.0]
+
 ### Uncategorized
 
 - Allow remaining TypeScript 5.x versions ([#422](https://github.com/MetaMask/eslint-config/pull/422))
@@ -128,7 +130,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - To continue extending this config, install this package and update your `.eslintrc.js` `extends` array to include `@metamask/eslint-config-jest` instead of `@metamask/eslint-config/jest`.
 - Update `eslint` and other ESLint peer dependencies ([#151](https://github.com/MetaMask/eslint-config/pull/151))
 
-[Unreleased]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-jest@14.1.0...HEAD
+[Unreleased]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-jest@15.0.0...HEAD
+[15.0.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-jest@14.1.0...@metamask/eslint-config-jest@15.0.0
 [14.1.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-jest@14.0.0...@metamask/eslint-config-jest@14.1.0
 [14.0.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-jest@13.0.0...@metamask/eslint-config-jest@14.0.0
 [13.0.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-jest@12.1.0...@metamask/eslint-config-jest@13.0.0

--- a/packages/jest/CHANGELOG.md
+++ b/packages/jest/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- Allow remaining TypeScript 5.x versions ([#422](https://github.com/MetaMask/eslint-config/pull/422))
+
 ### Changed
 
 - **BREAKING:** Convert various rules from `warn` to `error` ([#424](https://github.com/MetaMask/eslint-config/pull/424))

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/eslint-config-jest",
-  "version": "14.1.0",
+  "version": "15.0.0",
   "description": "Shareable MetaMask ESLint config for Jest.",
   "homepage": "https://github.com/MetaMask/eslint-config#readme",
   "bugs": {

--- a/packages/mocha/CHANGELOG.md
+++ b/packages/mocha/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [15.0.0]
+
 ### Uncategorized
 
 - Bump vite and vitest to address security vulns ([#393](https://github.com/MetaMask/eslint-config/pull/393))
@@ -113,7 +115,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - To continue extending this config, install this package and update your `.eslintrc.js` `extends` array to include `@metamask/eslint-config-mocha` instead of `@metamask/eslint-config/mocha`.
 - Update `eslint` and other ESLint peer dependencies ([#151](https://github.com/MetaMask/eslint-config/pull/151))
 
-[Unreleased]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-mocha@14.0.0...HEAD
+[Unreleased]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-mocha@15.0.0...HEAD
+[15.0.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-mocha@14.0.0...@metamask/eslint-config-mocha@15.0.0
 [14.0.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-mocha@13.0.0...@metamask/eslint-config-mocha@14.0.0
 [13.0.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-mocha@12.1.0...@metamask/eslint-config-mocha@13.0.0
 [12.1.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-mocha@12.0.0...@metamask/eslint-config-mocha@12.1.0

--- a/packages/mocha/CHANGELOG.md
+++ b/packages/mocha/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- Bump vite and vitest to address security vulns ([#393](https://github.com/MetaMask/eslint-config/pull/393))
+
 ## [14.0.0]
 
 ### Changed

--- a/packages/mocha/CHANGELOG.md
+++ b/packages/mocha/CHANGELOG.md
@@ -9,9 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [15.0.0]
 
-### Uncategorized
+### Changed
 
-- Bump vite and vitest to address security vulns ([#393](https://github.com/MetaMask/eslint-config/pull/393))
+- **BREAKING:** Bump peer dependency on `@metamask/eslint-config` from `^14.0.0` to `^15.0.0` ([#431](https://github.com/MetaMask/eslint-config/pull/431))
 
 ## [14.0.0]
 

--- a/packages/mocha/package.json
+++ b/packages/mocha/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/eslint-config-mocha",
-  "version": "14.0.0",
+  "version": "15.0.0",
   "description": "Shareable MetaMask ESLint config for Mocha.",
   "homepage": "https://github.com/MetaMask/eslint-config#readme",
   "bugs": {

--- a/packages/nodejs/CHANGELOG.md
+++ b/packages/nodejs/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- Bump vite and vitest to address security vulns ([#393](https://github.com/MetaMask/eslint-config/pull/393))
+
 ## [14.0.0]
 
 ### Changed

--- a/packages/nodejs/CHANGELOG.md
+++ b/packages/nodejs/CHANGELOG.md
@@ -9,9 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [15.0.0]
 
-### Uncategorized
+### Changed
 
-- Bump vite and vitest to address security vulns ([#393](https://github.com/MetaMask/eslint-config/pull/393))
+- **BREAKING:** Bump peer dependency on `@metamask/eslint-config` from `^14.0.0` to `^15.0.0` ([#431](https://github.com/MetaMask/eslint-config/pull/431))
 
 ## [14.0.0]
 

--- a/packages/nodejs/CHANGELOG.md
+++ b/packages/nodejs/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [15.0.0]
+
 ### Uncategorized
 
 - Bump vite and vitest to address security vulns ([#393](https://github.com/MetaMask/eslint-config/pull/393))
@@ -127,7 +129,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - To continue extending this config, install this package and update your `.eslintrc.js` `extends` array to include `@metamask/eslint-config-nodejs` instead of `@metamask/eslint-config/nodejs`.
 - Update `eslint` and other ESLint peer dependencies ([#151](https://github.com/MetaMask/eslint-config/pull/151))
 
-[Unreleased]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-nodejs@14.0.0...HEAD
+[Unreleased]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-nodejs@15.0.0...HEAD
+[15.0.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-nodejs@14.0.0...@metamask/eslint-config-nodejs@15.0.0
 [14.0.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-nodejs@13.0.0...@metamask/eslint-config-nodejs@14.0.0
 [13.0.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-nodejs@12.1.0...@metamask/eslint-config-nodejs@13.0.0
 [12.1.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-nodejs@12.0.0...@metamask/eslint-config-nodejs@12.1.0

--- a/packages/nodejs/package.json
+++ b/packages/nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/eslint-config-nodejs",
-  "version": "14.0.0",
+  "version": "15.0.0",
   "description": "Shareable MetaMask ESLint config for Node.js.",
   "homepage": "https://github.com/MetaMask/eslint-config#readme",
   "bugs": {

--- a/packages/typescript/CHANGELOG.md
+++ b/packages/typescript/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [15.0.0]
+
 ### Uncategorized
 
 - Allow remaining TypeScript 5.x versions ([#422](https://github.com/MetaMask/eslint-config/pull/422))
@@ -209,7 +211,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - To continue extending this config, install this package and update your `.eslintrc.js` `extends` array to include `@metamask/eslint-config-typescript` instead of `@metamask/eslint-config/typescript`.
 - Update `eslint` and other ESLint peer dependencies ([#151](https://github.com/MetaMask/eslint-config/pull/151))
 
-[Unreleased]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-typescript@14.1.0...HEAD
+[Unreleased]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-typescript@15.0.0...HEAD
+[15.0.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-typescript@14.1.0...@metamask/eslint-config-typescript@15.0.0
 [14.1.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-typescript@14.0.0...@metamask/eslint-config-typescript@14.1.0
 [14.0.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-typescript@13.0.0...@metamask/eslint-config-typescript@14.0.0
 [13.0.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-typescript@12.1.0...@metamask/eslint-config-typescript@13.0.0

--- a/packages/typescript/CHANGELOG.md
+++ b/packages/typescript/CHANGELOG.md
@@ -9,15 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [15.0.0]
 
-### Uncategorized
-
-- Allow remaining TypeScript 5.x versions ([#422](https://github.com/MetaMask/eslint-config/pull/422))
-- Revert "Revert "feat(typescript): Update type import specifier rules"" ([#418](https://github.com/MetaMask/eslint-config/pull/418))
-
 ### Changed
 
+- **BREAKING:** Bump peer dependency on `@metamask/eslint-config` from `^14.0.0` to `^15.0.0` ([#431](https://github.com/MetaMask/eslint-config/pull/431))
 - **BREAKING:** Update `typescript-eslint` peer dependency to have a minimum version of v8.39.0 ([#423](https://github.com/MetaMask/eslint-config/pull/423))
   - This version has a matching supported `typescript` range, and includes some bug fixes for problems we ran into.
+- **BREAKING:** Update type import specifier rules ([#381](https://github.com/MetaMask/eslint-config/pull/381))
+  - `@typescript-eslint/consistent-type-imports` has been replaced with `import-x/consistent-type-specifier-style`
+  - The rule now prefers "top-level" type imports over inline. e.g. `import type { a } from 'x'` over `import { type a } from 'x'`
 - Disable `@typescript-eslint/no-unnecessary-type-arguments` ([#426](https://github.com/MetaMask/eslint-config/pull/426))
   - We decided that "unnecessary" type arguments make types easier to read sometimes, so we should allow them.
 - Disable `promise/valid-params` because it's redundant in type-checked projects ([#425](https://github.com/MetaMask/eslint-config/pull/425))
@@ -27,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Object literals are too often used as parameters for 3rd party libraries/services.
 - Disable `jsdoc/check-indentation` ([#430](https://github.com/MetaMask/eslint-config/pull/430))
   - Disabled due to a problem with indended sections in TSDoc blocks.
+- Widen `typescript` peer dependency to allow all 5.x versions ([#422](https://github.com/MetaMask/eslint-config/pull/422))
 
 ### Fixed
 

--- a/packages/typescript/CHANGELOG.md
+++ b/packages/typescript/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- Allow remaining TypeScript 5.x versions ([#422](https://github.com/MetaMask/eslint-config/pull/422))
+- Revert "Revert "feat(typescript): Update type import specifier rules"" ([#418](https://github.com/MetaMask/eslint-config/pull/418))
+
 ### Changed
 
 - **BREAKING:** Update `typescript-eslint` peer dependency to have a minimum version of v8.39.0 ([#423](https://github.com/MetaMask/eslint-config/pull/423))

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/eslint-config-typescript",
-  "version": "14.1.0",
+  "version": "15.0.0",
   "description": "Shareable MetaMask ESLint config for TypeScript.",
   "homepage": "https://github.com/MetaMask/eslint-config#readme",
   "bugs": {

--- a/packages/vitest/CHANGELOG.md
+++ b/packages/vitest/CHANGELOG.md
@@ -9,9 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [15.0.0]
 
-### Uncategorized
+### Changed
 
-- Bump vite and vitest to address security vulns ([#393](https://github.com/MetaMask/eslint-config/pull/393))
+- **BREAKING:** Bump peer dependency on `@metamask/eslint-config` from `^14.0.0` to `^15.0.0` ([#431](https://github.com/MetaMask/eslint-config/pull/431))
+- Bump version to v15 rather than v2 to synchronize this with the other lint config packages ([#431](https://github.com/MetaMask/eslint-config/pull/431))
 
 ## [1.0.0]
 

--- a/packages/vitest/CHANGELOG.md
+++ b/packages/vitest/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [15.0.0]
+
 ### Uncategorized
 
 - Bump vite and vitest to address security vulns ([#393](https://github.com/MetaMask/eslint-config/pull/393))
@@ -19,5 +21,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - This config is based on the `@metamask/eslint-config-jest` config, but uses
     the Vitest plugin instead of Jest.
 
-[Unreleased]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-vitest@1.0.0...HEAD
+[Unreleased]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-vitest@15.0.0...HEAD
+[15.0.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-vitest@1.0.0...@metamask/eslint-config-vitest@15.0.0
 [1.0.0]: https://github.com/MetaMask/eslint-config/releases/tag/@metamask/eslint-config-vitest@1.0.0

--- a/packages/vitest/CHANGELOG.md
+++ b/packages/vitest/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- Bump vite and vitest to address security vulns ([#393](https://github.com/MetaMask/eslint-config/pull/393))
+
 ## [1.0.0]
 
 ### Added

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/eslint-config-vitest",
-  "version": "1.0.0",
+  "version": "15.0.0",
   "description": "Shareable MetaMask ESLint config for Vitest.",
   "homepage": "https://github.com/MetaMask/eslint-config#readme",
   "bugs": {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Publishes v15.0.0 with stricter JSDoc requirements, escalates select rules to errors, updates TypeScript rules/peer deps, and bumps peer deps across all configs.
> 
> - **Base (`@metamask/eslint-config`)**:
>   - **BREAKING:** Expand `jsdoc/require-jsdoc` coverage (arrow functions, classes, TS enums/interfaces/types, methods, etc.).
>   - **BREAKING:** Promote several `promise/*` rules from `warn` to `error`.
> - **TypeScript (`@metamask/eslint-config-typescript`)**:
>   - **BREAKING:** Require `typescript-eslint@>=8.39.0`; switch to `import-x/consistent-type-specifier-style` preferring top-level type imports.
>   - Disable `@typescript-eslint/no-unnecessary-type-arguments`, `promise/valid-params`, and `import-x/no-duplicates`; loosen naming for object literal properties; disable `jsdoc/check-indentation`.
>   - Widen `typescript` peer range to all 5.x; fix issues with type-import grouping and TSDoc indentation.
> - **Test configs**:
>   - **Jest:** Bump peer on base to `^15.0.0`; promote select `jest/*` rules to `error`; widen `typescript` peer to 5.x.
>   - **Vitest:** Version aligned to `15.0.0`; bump peer on base to `^15.0.0`.
> - **Environment configs**:
>   - **Browser, CommonJS, Node.js, Mocha:** Bump versions to `15.0.0` and peer on base to `^15.0.0`.
> - **Repo**:
>   - Root version to `15.0.0`; update changelogs and comparison links.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5eaa19a260247e3ce807c96666cffbd3eb9996e4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->