### PR TITLE
Fix TS package not to override base no-restricted-syntax selectors

### DIFF
--- a/packages/typescript/CHANGELOG.md
+++ b/packages/typescript/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **BREAKING:** Restrict usage of `with`, `in`, and sequence expressions, which should have been inherited from the base config but were overwritten
+
 ## [15.0.0]
 
 ### Changed

--- a/packages/typescript/CHANGELOG.md
+++ b/packages/typescript/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **BREAKING:** Restrict usage of `with`, `in`, and sequence expressions, which should have been inherited from the base config but were overwritten
+- **BREAKING:** Restrict usage of `with`, `in`, and sequence expressions, which should have been inherited from the base config but were overwritten ([#436](https://github.com/MetaMask/eslint-config/pull/436))
 
 ## [15.0.0]
 

--- a/packages/typescript/CHANGELOG.md
+++ b/packages/typescript/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **BREAKING:** Restrict usage of `with`, `in`, and sequence expressions, which should have been inherited from the base config but were overwritten ([#436](https://github.com/MetaMask/eslint-config/pull/436))
+- **BREAKING:** Restrict usage of `with`, `in`, and sequence expressions, which should have been inherited from the base config but were mistakenly overridden ([#436](https://github.com/MetaMask/eslint-config/pull/436))
 
 ## [15.0.0]
 

--- a/packages/typescript/rules-snapshot.json
+++ b/packages/typescript/rules-snapshot.json
@@ -227,6 +227,18 @@
   "no-restricted-syntax": [
     "error",
     {
+      "selector": "WithStatement",
+      "message": "With statements are not allowed"
+    },
+    {
+      "selector": "BinaryExpression[operator='in']",
+      "message": "The \"in\" operator is not allowed"
+    },
+    {
+      "selector": "SequenceExpression",
+      "message": "Sequence expressions are not allowed"
+    },
+    {
       "selector": "PropertyDefinition[accessibility='private'], MethodDefinition[accessibility='private'], TSParameterProperty[accessibility='private']",
       "message": "Use a hash name instead."
     }

--- a/packages/typescript/src/index.mjs
+++ b/packages/typescript/src/index.mjs
@@ -1,10 +1,41 @@
-import { createConfig } from '@metamask/eslint-config';
+import base, { createConfig } from '@metamask/eslint-config';
 import * as resolver from 'eslint-import-resolver-typescript';
 import importX from 'eslint-plugin-import-x';
 import jsdoc from 'eslint-plugin-jsdoc';
 // TODO: Look into why this doesn't resolve.
 // eslint-disable-next-line import-x/no-unresolved
 import typescript from 'typescript-eslint';
+
+/**
+ * Collects all options for a given array-valued rule across one or more flat
+ * config arrays, excluding the leading severity element.
+ *
+ * ESLint flat config does not merge array-valued rules across config objects —
+ * a later config silently replaces earlier ones. This helper makes it possible
+ * to extend an upstream rule configuration rather than copy-pasting its options.
+ *
+ * @param {string} ruleName - The rule to collect options for.
+ * @param {import('eslint').Linter.Config[][]} configs - Flat config arrays to
+ * collect options from.
+ * @returns {unknown[]} The options from all matching rule entries, with the
+ * leading severity element omitted.
+ */
+function collectExistingRuleOptions(ruleName, configs) {
+  return configs.flat().flatMap((config) => {
+    const rule = config.rules?.[ruleName];
+    if (!Array.isArray(rule)) {
+      return [];
+    }
+    // Rule entries are ['error' | 'warn' | number, ...options].
+    // Skip the first element (severity) and collect the rest.
+    return rule.slice(1);
+  });
+}
+
+const baseNoRestrictedSyntaxOptions = collectExistingRuleOptions(
+  'no-restricted-syntax',
+  base,
+);
 
 const config = createConfig({
   name: '@metamask/eslint-config-typescript',
@@ -234,6 +265,7 @@ const config = createConfig({
     // Prefer hash names over TypeScript's `private` modifier.
     'no-restricted-syntax': [
       'error',
+      ...baseNoRestrictedSyntaxOptions,
       {
         selector:
           "PropertyDefinition[accessibility='private'], MethodDefinition[accessibility='private'], TSParameterProperty[accessibility='private']",


### PR DESCRIPTION
Both the `eslint-config` and `eslint-config-typescript` packages list the `no-restricted-syntax` rule. But `eslint-config-typescript` overwrites the selectors that `eslint-config` specifies, meaning that some invalid syntax is not detected in TypeScript files that would ordinarily be detected in JavaScript files. This commit ensures that the two are always kept in sync.

Fixes #434.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes TypeScript linting behavior by re-enabling base `no-restricted-syntax` selectors (`with`, `in`, sequence expressions), which can introduce new lint failures across TS codebases. The merge logic is small but relies on correctly collecting/ordering rule options from the base flat config.
> 
> **Overview**
> Fixes `@metamask/eslint-config-typescript` so it no longer silently *overwrites* the base `no-restricted-syntax` configuration in flat config mode.
> 
> The TypeScript config now imports the base config and programmatically collects/extends its array-valued rule options, ensuring TS files also forbid `with` statements, the `in` operator, and sequence expressions while still adding the TypeScript-specific restriction against TS `private` modifiers.
> 
> Updates the TypeScript package `rules-snapshot.json` and documents the (breaking) linting fix in the TypeScript changelog.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 107bcfea099610b571fb8681159a8f009baa50c8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->