### PR TITLE
Require documentation for exported variables

### DIFF
--- a/packages/base/CHANGELOG.md
+++ b/packages/base/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **BREAKING:** Update `jsdoc/require-jsdoc` to require JSDoc for exported variable declarations ([#437](https://github.com/MetaMask/eslint-config/pull/437))
 - Update `jsdoc/require-jsdoc` to loosen requirements for various kinds of symbols ([#433](https://github.com/MetaMask/eslint-config/pull/433))
 
   - JSDoc is no longer required for arrow functions or function expressions which are values of object properties:

--- a/packages/base/rules-snapshot.json
+++ b/packages/base/rules-snapshot.json
@@ -186,7 +186,8 @@
       },
       "contexts": [
         ":not(Property, NewExpression, CallExpression) > ArrowFunctionExpression",
-        ":not(Property, NewExpression, CallExpression) > FunctionExpression"
+        ":not(Property, NewExpression, CallExpression) > FunctionExpression",
+        "ExportNamedDeclaration:has(> VariableDeclaration)"
       ]
     }
   ],

--- a/packages/base/src/index.mjs
+++ b/packages/base/src/index.mjs
@@ -411,6 +411,8 @@ const rules = createConfig({
           // Function expressions that are not contained within plain objects
           // or are not arguments to functions or methods
           ':not(Property, NewExpression, CallExpression) > FunctionExpression',
+          // Exported variables
+          'ExportNamedDeclaration:has(> VariableDeclaration)',
         ],
       },
     ],

--- a/packages/typescript/CHANGELOG.md
+++ b/packages/typescript/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **BREAKING:** Update `jsdoc/require-jsdoc` to require documentation for more things ([#394](https://github.com/MetaMask/eslint-config/pull/394), ([#437](https://github.com/MetaMask/eslint-config/pull/437))
+- **BREAKING:** Update `jsdoc/require-jsdoc` to require documentation for more things ([#394](https://github.com/MetaMask/eslint-config/pull/394), [#437](https://github.com/MetaMask/eslint-config/pull/437))
   - New things that now require documentation are:
     - Arrow functions (except those which are arguments to functions/methods or values of object properties)
     - Class declarations

--- a/packages/typescript/CHANGELOG.md
+++ b/packages/typescript/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **BREAKING:** Update `jsdoc/require-jsdoc` to require documentation for more things ([#394](https://github.com/MetaMask/eslint-config/pull/394))
+- **BREAKING:** Update `jsdoc/require-jsdoc` to require documentation for more things ([#394](https://github.com/MetaMask/eslint-config/pull/394), ([#437](https://github.com/MetaMask/eslint-config/pull/437))
   - New things that now require documentation are:
     - Arrow functions (except those which are arguments to functions/methods or values of object properties)
     - Class declarations
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - TypeScript interface declarations (except those defined in a `declare` block)
     - TypeScript type alias declarations (except those defined in a `declare` block)
     - TypeScript property signatures withiin interfaces or type aliases
+    - Exported variable declarations
 
 ### Fixed
 

--- a/packages/typescript/rules-snapshot.json
+++ b/packages/typescript/rules-snapshot.json
@@ -201,6 +201,7 @@
       "contexts": [
         ":not(Property, NewExpression, CallExpression) > ArrowFunctionExpression",
         ":not(Property, NewExpression, CallExpression) > FunctionExpression",
+        "ExportNamedDeclaration:has(> VariableDeclaration)",
         ":not(TSModuleBlock, TSModuleBlock > ExportNamedDeclaration) > TSInterfaceDeclaration",
         ":not(TSModuleBlock, TSModuleBlock > ExportNamedDeclaration) > TSTypeAliasDeclaration",
         ":not(TSModuleBlock, TSModuleBlock > ExportNamedDeclaration) > TSEnumDeclaration",


### PR DESCRIPTION
It's common to define a constant, assign it to a variable, and export it in one go:

```typescript
export const POLLING_INTERVAL = 30 * 1000;
```

Exporting a variable signifies it is important in some way, and so we want them to be documented for other engineers (even if it is not ultimately exported from the entire package).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This is a breaking linting change that will introduce new `jsdoc/require-jsdoc` errors for `export const/let/var` declarations across consuming codebases. Risk is limited to developer workflow/config behavior (no runtime impact), but may cause widespread CI failures until docs are added.
> 
> **Overview**
> **Breaking linting update:** `jsdoc/require-jsdoc` now also requires JSDoc for **exported variable declarations** (e.g. `export const FOO = ...`) in both the base and TypeScript configs.
> 
> Updates the generated `rules-snapshot.json` files accordingly and documents the new requirement in both package changelogs (including updating the prior breaking-change entry in the TypeScript changelog).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c9f2dcd737273e1af627b78e9511bea7e4b935e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->