### PR TITLE
fix: allow import from CommonJS

### DIFF
--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -14,10 +14,8 @@
   "type": "module",
   "exports": {
     ".": {
-      "import": {
-        "types": "./src/index.d.mts",
-        "default": "./src/index.mjs"
-      }
+      "types": "./src/index.d.mts",
+      "default": "./src/index.mjs"
     }
   },
   "main": "./src/index.mjs",

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -14,10 +14,8 @@
   "type": "module",
   "exports": {
     ".": {
-      "import": {
-        "types": "./src/index.d.mts",
-        "default": "./src/index.mjs"
-      }
+      "types": "./src/index.d.mts",
+      "default": "./src/index.mjs"
     }
   },
   "main": "./src/index.mjs",

--- a/packages/commonjs/package.json
+++ b/packages/commonjs/package.json
@@ -14,10 +14,8 @@
   "type": "module",
   "exports": {
     ".": {
-      "import": {
-        "types": "./src/index.d.mts",
-        "default": "./src/index.mjs"
-      }
+      "types": "./src/index.d.mts",
+      "default": "./src/index.mjs"
     }
   },
   "main": "./src/index.mjs",

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -14,10 +14,8 @@
   "type": "module",
   "exports": {
     ".": {
-      "import": {
-        "types": "./src/index.d.mts",
-        "default": "./src/index.mjs"
-      }
+      "types": "./src/index.d.mts",
+      "default": "./src/index.mjs"
     }
   },
   "main": "./src/index.mjs",

--- a/packages/mocha/package.json
+++ b/packages/mocha/package.json
@@ -14,10 +14,8 @@
   "type": "module",
   "exports": {
     ".": {
-      "import": {
-        "types": "./src/index.d.mts",
-        "default": "./src/index.mjs"
-      }
+      "types": "./src/index.d.mts",
+      "default": "./src/index.mjs"
     }
   },
   "main": "./src/index.mjs",

--- a/packages/nodejs/package.json
+++ b/packages/nodejs/package.json
@@ -14,10 +14,8 @@
   "type": "module",
   "exports": {
     ".": {
-      "import": {
-        "types": "./src/index.d.mts",
-        "default": "./src/index.mjs"
-      }
+      "types": "./src/index.d.mts",
+      "default": "./src/index.mjs"
     }
   },
   "main": "./src/index.mjs",

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -14,10 +14,8 @@
   "type": "module",
   "exports": {
     ".": {
-      "import": {
-        "types": "./src/index.d.mts",
-        "default": "./src/index.mjs"
-      }
+      "types": "./src/index.d.mts",
+      "default": "./src/index.mjs"
     }
   },
   "main": "./src/index.mjs",

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -14,10 +14,8 @@
   "type": "module",
   "exports": {
     ".": {
-      "import": {
-        "types": "./src/index.d.mts",
-        "default": "./src/index.mjs"
-      }
+      "types": "./src/index.d.mts",
+      "default": "./src/index.mjs"
     }
   },
   "main": "./src/index.mjs",


### PR DESCRIPTION
The `exports` field in each of our ESLint config packages used an `import` condition with no `require` or `default` condition alongside it, which broke compatbility with CommonJS. The condition has been removed.

This has no impact on ESM modules, but it allows import from CommonJS modules.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging-only `exports` map change with identical entry file paths; low risk aside from verifying CJS and ESM consumers still resolve types and the main entry.
> 
> **Overview**
> Fixes **CommonJS consumers** (e.g. `require('@metamask/eslint-config')` or CJS ESLint configs) that could not resolve these packages because `package.json` `exports["."]` only defined an **`import`** condition.
> 
> Across all eight published config packages (`base`, `browser`, `commonjs`, `jest`, `mocha`, `nodejs`, `typescript`, `vitest`), the export map is flattened so **`types`** and **`default`** sit directly under `"."` instead of under `import`. Resolution still points at the same `./src/index.mjs` and `./src/index.d.mts` files; **ESM `import` behavior is unchanged**, while **`default`** can be used when the resolver does not apply the `import` condition.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00f5812eac8134711af02bb8aed3978539de0b23. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->