### PR TITLE
chore: update changelog for #453

### DIFF
--- a/packages/base/CHANGELOG.md
+++ b/packages/base/CHANGELOG.md
@@ -44,6 +44,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     }):
     ```
 
+### Fixed
+
+- Allow import from CommonJS ([#453](https://github.com/MetaMask/eslint-config/pull/453))
+
 ## [15.0.0]
 
 ### Changed

--- a/packages/browser/CHANGELOG.md
+++ b/packages/browser/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Allow import from CommonJS ([#453](https://github.com/MetaMask/eslint-config/pull/453))
+
 ## [15.0.0]
 
 ### Changed

--- a/packages/commonjs/CHANGELOG.md
+++ b/packages/commonjs/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Allow import from CommonJS ([#453](https://github.com/MetaMask/eslint-config/pull/453))
+
 ## [15.0.0]
 
 ### Changed

--- a/packages/jest/CHANGELOG.md
+++ b/packages/jest/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Allow import from CommonJS ([#453](https://github.com/MetaMask/eslint-config/pull/453))
+
 ## [15.0.0]
 
 ### Changed

--- a/packages/mocha/CHANGELOG.md
+++ b/packages/mocha/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Allow import from CommonJS ([#453](https://github.com/MetaMask/eslint-config/pull/453))
+
 ## [15.0.0]
 
 ### Changed

--- a/packages/nodejs/CHANGELOG.md
+++ b/packages/nodejs/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Allow import from CommonJS ([#453](https://github.com/MetaMask/eslint-config/pull/453))
+
 ## [15.0.0]
 
 ### Changed

--- a/packages/typescript/CHANGELOG.md
+++ b/packages/typescript/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **BREAKING:** Restrict usage of `with`, `in`, and sequence expressions, which should have been inherited from the base config but were mistakenly overridden ([#436](https://github.com/MetaMask/eslint-config/pull/436))
+- Allow import from CommonJS ([#453](https://github.com/MetaMask/eslint-config/pull/453))
 
 ## [15.0.0]
 

--- a/packages/vitest/CHANGELOG.md
+++ b/packages/vitest/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Allow import from CommonJS ([#453](https://github.com/MetaMask/eslint-config/pull/453))
+
 ## [15.0.0]
 
 ### Changed


### PR DESCRIPTION
Changelogs have been updated for #453 (I forgot to update them in the PR).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changelog-only follow-up with no behavioral or dependency changes.
> 
> **Overview**
> Adds **Unreleased** changelog entries across the monorepo packages (`base`, `browser`, `commonjs`, `jest`, `mocha`, `nodejs`, `typescript`, `vitest`) for the fix shipped in [#453](https://github.com/MetaMask/eslint-config/pull/453): **Allow import from CommonJS**.
> 
> `packages/base` gets a new **Fixed** section under `[Unreleased]`; the other packages add the same bullet under **Fixed**. `packages/typescript` appends the entry to its existing **Fixed** section rather than creating a new one.
> 
> No runtime or config code changes—documentation only, catching up release notes that were omitted when #453 merged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27b55407252ef710f566f23bfb6e874e276c2f56. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->