### PR TITLE
Release/14.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/eslint-config-root",
-  "version": "14.1.0",
+  "version": "14.1.1",
   "private": true,
   "repository": {
     "type": "git",

--- a/packages/base/CHANGELOG.md
+++ b/packages/base/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Allow import from CommonJS ([#453](https://github.com/MetaMask/eslint-config/pull/453))
+
 ## [14.1.0]
 
 ### Changed

--- a/packages/base/CHANGELOG.md
+++ b/packages/base/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [14.1.1] [BACKPORT]
+
 ### Fixed
 
 - Allow import from CommonJS ([#453](https://github.com/MetaMask/eslint-config/pull/453))
@@ -274,7 +276,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add base, TypeScript, and Jest configs (#3)
 
-[Unreleased]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config@14.1.0...HEAD
+[Unreleased]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config@14.1.1...HEAD
+[14.1.1]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config@14.1.0...@metamask/eslint-config@14.1.1
 [14.1.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config@14.0.0...@metamask/eslint-config@14.1.0
 [14.0.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config@13.0.0...@metamask/eslint-config@14.0.0
 [13.0.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config@12.2.0...@metamask/eslint-config@13.0.0

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -14,10 +14,8 @@
   "type": "module",
   "exports": {
     ".": {
-      "import": {
-        "types": "./src/index.d.mts",
-        "default": "./src/index.mjs"
-      }
+      "types": "./src/index.d.mts",
+      "default": "./src/index.mjs"
     }
   },
   "main": "./src/index.mjs",

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/eslint-config",
-  "version": "14.1.0",
+  "version": "14.1.1",
   "description": "Shareable MetaMask ESLint config.",
   "homepage": "https://github.com/MetaMask/eslint-config#readme",
   "bugs": {

--- a/packages/browser/CHANGELOG.md
+++ b/packages/browser/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Allow import from CommonJS ([#453](https://github.com/MetaMask/eslint-config/pull/453))
+
 ## [14.0.0]
 
 ### Changed

--- a/packages/browser/CHANGELOG.md
+++ b/packages/browser/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [14.0.1] [BACKPORT]
+
 ### Fixed
 
 - Allow import from CommonJS ([#453](https://github.com/MetaMask/eslint-config/pull/453))
@@ -58,7 +60,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release of this package.
 
-[Unreleased]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-browser@14.0.0...HEAD
+[Unreleased]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-browser@14.0.1...HEAD
+[14.0.1]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-browser@14.0.0...@metamask/eslint-config-browser@14.0.1
 [14.0.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-browser@13.0.0...@metamask/eslint-config-browser@14.0.0
 [13.0.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-browser@12.1.0...@metamask/eslint-config-browser@13.0.0
 [12.1.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-browser@12.0.0...@metamask/eslint-config-browser@12.1.0

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -14,10 +14,8 @@
   "type": "module",
   "exports": {
     ".": {
-      "import": {
-        "types": "./src/index.d.mts",
-        "default": "./src/index.mjs"
-      }
+      "types": "./src/index.d.mts",
+      "default": "./src/index.mjs"
     }
   },
   "main": "./src/index.mjs",

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/eslint-config-browser",
-  "version": "14.0.0",
+  "version": "14.0.1",
   "description": "Shareable MetaMask ESLint plugin for browser environments.",
   "homepage": "https://github.com/MetaMask/eslint-config#readme",
   "bugs": {

--- a/packages/commonjs/CHANGELOG.md
+++ b/packages/commonjs/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Allow import from CommonJS ([#453](https://github.com/MetaMask/eslint-config/pull/453))
+
 ## [14.0.0]
 
 ### Changed

--- a/packages/commonjs/CHANGELOG.md
+++ b/packages/commonjs/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [14.0.1] [BACKPORT]
+
 ### Fixed
 
 - Allow import from CommonJS ([#453](https://github.com/MetaMask/eslint-config/pull/453))
@@ -53,7 +55,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release of this package ([#267](https://github.com/MetaMask/eslint-config/pull/267))
 
-[Unreleased]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-commonjs@14.0.0...HEAD
+[Unreleased]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-commonjs@14.0.1...HEAD
+[14.0.1]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-commonjs@14.0.0...@metamask/eslint-config-commonjs@14.0.1
 [14.0.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-commonjs@13.0.0...@metamask/eslint-config-commonjs@14.0.0
 [13.0.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-commonjs@12.1.0...@metamask/eslint-config-commonjs@13.0.0
 [12.1.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-commonjs@12.0.0...@metamask/eslint-config-commonjs@12.1.0

--- a/packages/commonjs/package.json
+++ b/packages/commonjs/package.json
@@ -14,10 +14,8 @@
   "type": "module",
   "exports": {
     ".": {
-      "import": {
-        "types": "./src/index.d.mts",
-        "default": "./src/index.mjs"
-      }
+      "types": "./src/index.d.mts",
+      "default": "./src/index.mjs"
     }
   },
   "main": "./src/index.mjs",

--- a/packages/commonjs/package.json
+++ b/packages/commonjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/eslint-config-commonjs",
-  "version": "14.0.0",
+  "version": "14.0.1",
   "description": "Shareable MetaMask ESLint config for CommonJS projects.",
   "homepage": "https://github.com/MetaMask/eslint-config#readme",
   "bugs": {

--- a/packages/jest/CHANGELOG.md
+++ b/packages/jest/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [14.1.1] [BACKPORT]
+
 ### Fixed
 
 - Allow import from CommonJS ([#453](https://github.com/MetaMask/eslint-config/pull/453))
@@ -119,7 +121,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - To continue extending this config, install this package and update your `.eslintrc.js` `extends` array to include `@metamask/eslint-config-jest` instead of `@metamask/eslint-config/jest`.
 - Update `eslint` and other ESLint peer dependencies ([#151](https://github.com/MetaMask/eslint-config/pull/151))
 
-[Unreleased]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-jest@14.1.0...HEAD
+[Unreleased]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-jest@14.1.1...HEAD
+[14.1.1]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-jest@14.1.0...@metamask/eslint-config-jest@14.1.1
 [14.1.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-jest@14.0.0...@metamask/eslint-config-jest@14.1.0
 [14.0.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-jest@13.0.0...@metamask/eslint-config-jest@14.0.0
 [13.0.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-jest@12.1.0...@metamask/eslint-config-jest@13.0.0

--- a/packages/jest/CHANGELOG.md
+++ b/packages/jest/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Allow import from CommonJS ([#453](https://github.com/MetaMask/eslint-config/pull/453))
+
 ## [14.1.0]
 
 ### Changed

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -14,10 +14,8 @@
   "type": "module",
   "exports": {
     ".": {
-      "import": {
-        "types": "./src/index.d.mts",
-        "default": "./src/index.mjs"
-      }
+      "types": "./src/index.d.mts",
+      "default": "./src/index.mjs"
     }
   },
   "main": "./src/index.mjs",

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/eslint-config-jest",
-  "version": "14.1.0",
+  "version": "14.1.1",
   "description": "Shareable MetaMask ESLint config for Jest.",
   "homepage": "https://github.com/MetaMask/eslint-config#readme",
   "bugs": {

--- a/packages/mocha/CHANGELOG.md
+++ b/packages/mocha/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [14.0.1] [BACKPORT]
+
 ### Fixed
 
 - Allow import from CommonJS ([#453](https://github.com/MetaMask/eslint-config/pull/453))
@@ -113,7 +115,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - To continue extending this config, install this package and update your `.eslintrc.js` `extends` array to include `@metamask/eslint-config-mocha` instead of `@metamask/eslint-config/mocha`.
 - Update `eslint` and other ESLint peer dependencies ([#151](https://github.com/MetaMask/eslint-config/pull/151))
 
-[Unreleased]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-mocha@14.0.0...HEAD
+[Unreleased]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-mocha@14.0.1...HEAD
+[14.0.1]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-mocha@14.0.0...@metamask/eslint-config-mocha@14.0.1
 [14.0.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-mocha@13.0.0...@metamask/eslint-config-mocha@14.0.0
 [13.0.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-mocha@12.1.0...@metamask/eslint-config-mocha@13.0.0
 [12.1.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-mocha@12.0.0...@metamask/eslint-config-mocha@12.1.0

--- a/packages/mocha/CHANGELOG.md
+++ b/packages/mocha/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Allow import from CommonJS ([#453](https://github.com/MetaMask/eslint-config/pull/453))
+
 ## [14.0.0]
 
 ### Changed

--- a/packages/mocha/package.json
+++ b/packages/mocha/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/eslint-config-mocha",
-  "version": "14.0.0",
+  "version": "14.0.1",
   "description": "Shareable MetaMask ESLint config for Mocha.",
   "homepage": "https://github.com/MetaMask/eslint-config#readme",
   "bugs": {

--- a/packages/mocha/package.json
+++ b/packages/mocha/package.json
@@ -14,10 +14,8 @@
   "type": "module",
   "exports": {
     ".": {
-      "import": {
-        "types": "./src/index.d.mts",
-        "default": "./src/index.mjs"
-      }
+      "types": "./src/index.d.mts",
+      "default": "./src/index.mjs"
     }
   },
   "main": "./src/index.mjs",

--- a/packages/nodejs/CHANGELOG.md
+++ b/packages/nodejs/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Allow import from CommonJS ([#453](https://github.com/MetaMask/eslint-config/pull/453))
+
 ## [14.0.0]
 
 ### Changed

--- a/packages/nodejs/CHANGELOG.md
+++ b/packages/nodejs/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [14.0.1] [BACKPORT]
+
 ### Fixed
 
 - Allow import from CommonJS ([#453](https://github.com/MetaMask/eslint-config/pull/453))
@@ -127,7 +129,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - To continue extending this config, install this package and update your `.eslintrc.js` `extends` array to include `@metamask/eslint-config-nodejs` instead of `@metamask/eslint-config/nodejs`.
 - Update `eslint` and other ESLint peer dependencies ([#151](https://github.com/MetaMask/eslint-config/pull/151))
 
-[Unreleased]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-nodejs@14.0.0...HEAD
+[Unreleased]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-nodejs@14.0.1...HEAD
+[14.0.1]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-nodejs@14.0.0...@metamask/eslint-config-nodejs@14.0.1
 [14.0.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-nodejs@13.0.0...@metamask/eslint-config-nodejs@14.0.0
 [13.0.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-nodejs@12.1.0...@metamask/eslint-config-nodejs@13.0.0
 [12.1.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-nodejs@12.0.0...@metamask/eslint-config-nodejs@12.1.0

--- a/packages/nodejs/package.json
+++ b/packages/nodejs/package.json
@@ -14,10 +14,8 @@
   "type": "module",
   "exports": {
     ".": {
-      "import": {
-        "types": "./src/index.d.mts",
-        "default": "./src/index.mjs"
-      }
+      "types": "./src/index.d.mts",
+      "default": "./src/index.mjs"
     }
   },
   "main": "./src/index.mjs",

--- a/packages/nodejs/package.json
+++ b/packages/nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/eslint-config-nodejs",
-  "version": "14.0.0",
+  "version": "14.0.1",
   "description": "Shareable MetaMask ESLint config for Node.js.",
   "homepage": "https://github.com/MetaMask/eslint-config#readme",
   "bugs": {

--- a/packages/typescript/CHANGELOG.md
+++ b/packages/typescript/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Allow import from CommonJS ([#453](https://github.com/MetaMask/eslint-config/pull/453))
+
 ## [14.1.0]
 
 ### Added

--- a/packages/typescript/CHANGELOG.md
+++ b/packages/typescript/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [14.1.1] [BACKPORT]
+
 ### Fixed
 
 - Allow import from CommonJS ([#453](https://github.com/MetaMask/eslint-config/pull/453))
@@ -188,7 +190,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - To continue extending this config, install this package and update your `.eslintrc.js` `extends` array to include `@metamask/eslint-config-typescript` instead of `@metamask/eslint-config/typescript`.
 - Update `eslint` and other ESLint peer dependencies ([#151](https://github.com/MetaMask/eslint-config/pull/151))
 
-[Unreleased]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-typescript@14.1.0...HEAD
+[Unreleased]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-typescript@14.1.1...HEAD
+[14.1.1]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-typescript@14.1.0...@metamask/eslint-config-typescript@14.1.1
 [14.1.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-typescript@14.0.0...@metamask/eslint-config-typescript@14.1.0
 [14.0.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-typescript@13.0.0...@metamask/eslint-config-typescript@14.0.0
 [13.0.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-typescript@12.1.0...@metamask/eslint-config-typescript@13.0.0

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -14,10 +14,8 @@
   "type": "module",
   "exports": {
     ".": {
-      "import": {
-        "types": "./src/index.d.mts",
-        "default": "./src/index.mjs"
-      }
+      "types": "./src/index.d.mts",
+      "default": "./src/index.mjs"
     }
   },
   "main": "./src/index.mjs",

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/eslint-config-typescript",
-  "version": "14.1.0",
+  "version": "14.1.1",
   "description": "Shareable MetaMask ESLint config for TypeScript.",
   "homepage": "https://github.com/MetaMask/eslint-config#readme",
   "bugs": {

--- a/packages/vitest/CHANGELOG.md
+++ b/packages/vitest/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Allow import from CommonJS ([#453](https://github.com/MetaMask/eslint-config/pull/453))
+
 ## [1.0.0]
 
 ### Added

--- a/packages/vitest/CHANGELOG.md
+++ b/packages/vitest/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.1] [BACKPORT]
+
 ### Fixed
 
 - Allow import from CommonJS ([#453](https://github.com/MetaMask/eslint-config/pull/453))
@@ -19,5 +21,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - This config is based on the `@metamask/eslint-config-jest` config, but uses
     the Vitest plugin instead of Jest.
 
-[Unreleased]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-vitest@1.0.0...HEAD
+[Unreleased]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-vitest@1.0.1...HEAD
+[1.0.1]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-vitest@1.0.0...@metamask/eslint-config-vitest@1.0.1
 [1.0.0]: https://github.com/MetaMask/eslint-config/releases/tag/@metamask/eslint-config-vitest@1.0.0

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/eslint-config-vitest",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Shareable MetaMask ESLint config for Vitest.",
   "homepage": "https://github.com/MetaMask/eslint-config#readme",
   "bugs": {

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -14,10 +14,8 @@
   "type": "module",
   "exports": {
     ".": {
-      "import": {
-        "types": "./src/index.d.mts",
-        "default": "./src/index.mjs"
-      }
+      "types": "./src/index.d.mts",
+      "default": "./src/index.mjs"
     }
   },
   "main": "./src/index.mjs",


### PR DESCRIPTION
This is a release candidate for v14.1.1, a backport release for v14.x

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging-only change with no lint rule or runtime logic edits; low risk aside from verifying export resolution in both ESM and CJS ESLint configs.
> 
> **Overview**
> **v14.1.1 backport release** that fixes how consumers resolve these ESLint config packages when loading them from CommonJS-style entry points (e.g. legacy `eslint.config.cjs`).
> 
> Every published workspace package updates **`package.json` `exports["."]`** from an **`import`-only** condition to top-level **`types`** + **`default`** pointing at the same ESM entry. That lets Node resolve the package when the importer is not using a pure ESM `import` condition, which had broken some setups after the v14 pure-ESM export map.
> 
> Patch version bumps and changelog entries are applied across **base**, **browser**, **commonjs**, **jest**, **mocha**, **nodejs**, **typescript**, and **vitest** (root monorepo version **14.1.1**). No ESLint rule or config source changes in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df7a2824b4294905e9603a7998c0c932118aff49. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->