### PR TITLE
Release/15.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/eslint-config-root",
-  "version": "15.0.0",
+  "version": "15.0.1",
   "private": true,
   "repository": {
     "type": "git",

--- a/packages/base/CHANGELOG.md
+++ b/packages/base/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Allow import from CommonJS ([#453](https://github.com/MetaMask/eslint-config/pull/453))
+
 ## [15.0.0]
 
 ### Changed

--- a/packages/base/CHANGELOG.md
+++ b/packages/base/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [15.0.1] [BACKPORT]
+
 ### Fixed
 
 - Allow import from CommonJS ([#453](https://github.com/MetaMask/eslint-config/pull/453))
@@ -296,7 +298,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add base, TypeScript, and Jest configs (#3)
 
-[Unreleased]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config@15.0.0...HEAD
+[Unreleased]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config@15.0.1...HEAD
+[15.0.1]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config@15.0.0...@metamask/eslint-config@15.0.1
 [15.0.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config@14.1.0...@metamask/eslint-config@15.0.0
 [14.1.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config@14.0.0...@metamask/eslint-config@14.1.0
 [14.0.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config@13.0.0...@metamask/eslint-config@14.0.0

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -14,10 +14,8 @@
   "type": "module",
   "exports": {
     ".": {
-      "import": {
-        "types": "./src/index.d.mts",
-        "default": "./src/index.mjs"
-      }
+      "types": "./src/index.d.mts",
+      "default": "./src/index.mjs"
     }
   },
   "main": "./src/index.mjs",

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/eslint-config",
-  "version": "15.0.0",
+  "version": "15.0.1",
   "description": "Shareable MetaMask ESLint config.",
   "homepage": "https://github.com/MetaMask/eslint-config#readme",
   "bugs": {

--- a/packages/browser/CHANGELOG.md
+++ b/packages/browser/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Allow import from CommonJS ([#453](https://github.com/MetaMask/eslint-config/pull/453))
+
 ## [15.0.0]
 
 ### Changed

--- a/packages/browser/CHANGELOG.md
+++ b/packages/browser/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [15.0.1] [BACKPORT]
+
 ### Fixed
 
 - Allow import from CommonJS ([#453](https://github.com/MetaMask/eslint-config/pull/453))
@@ -64,7 +66,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release of this package.
 
-[Unreleased]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-browser@15.0.0...HEAD
+[Unreleased]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-browser@15.0.1...HEAD
+[15.0.1]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-browser@15.0.0...@metamask/eslint-config-browser@15.0.1
 [15.0.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-browser@14.0.0...@metamask/eslint-config-browser@15.0.0
 [14.0.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-browser@13.0.0...@metamask/eslint-config-browser@14.0.0
 [13.0.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-browser@12.1.0...@metamask/eslint-config-browser@13.0.0

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -14,10 +14,8 @@
   "type": "module",
   "exports": {
     ".": {
-      "import": {
-        "types": "./src/index.d.mts",
-        "default": "./src/index.mjs"
-      }
+      "types": "./src/index.d.mts",
+      "default": "./src/index.mjs"
     }
   },
   "main": "./src/index.mjs",

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/eslint-config-browser",
-  "version": "15.0.0",
+  "version": "15.0.1",
   "description": "Shareable MetaMask ESLint plugin for browser environments.",
   "homepage": "https://github.com/MetaMask/eslint-config#readme",
   "bugs": {

--- a/packages/commonjs/CHANGELOG.md
+++ b/packages/commonjs/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Allow import from CommonJS ([#453](https://github.com/MetaMask/eslint-config/pull/453))
+
 ## [15.0.0]
 
 ### Changed

--- a/packages/commonjs/CHANGELOG.md
+++ b/packages/commonjs/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [15.0.1] [BACKPORT]
+
 ### Fixed
 
 - Allow import from CommonJS ([#453](https://github.com/MetaMask/eslint-config/pull/453))
@@ -59,7 +61,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release of this package ([#267](https://github.com/MetaMask/eslint-config/pull/267))
 
-[Unreleased]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-commonjs@15.0.0...HEAD
+[Unreleased]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-commonjs@15.0.1...HEAD
+[15.0.1]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-commonjs@15.0.0...@metamask/eslint-config-commonjs@15.0.1
 [15.0.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-commonjs@14.0.0...@metamask/eslint-config-commonjs@15.0.0
 [14.0.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-commonjs@13.0.0...@metamask/eslint-config-commonjs@14.0.0
 [13.0.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-commonjs@12.1.0...@metamask/eslint-config-commonjs@13.0.0

--- a/packages/commonjs/package.json
+++ b/packages/commonjs/package.json
@@ -14,10 +14,8 @@
   "type": "module",
   "exports": {
     ".": {
-      "import": {
-        "types": "./src/index.d.mts",
-        "default": "./src/index.mjs"
-      }
+      "types": "./src/index.d.mts",
+      "default": "./src/index.mjs"
     }
   },
   "main": "./src/index.mjs",

--- a/packages/commonjs/package.json
+++ b/packages/commonjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/eslint-config-commonjs",
-  "version": "15.0.0",
+  "version": "15.0.1",
   "description": "Shareable MetaMask ESLint config for CommonJS projects.",
   "homepage": "https://github.com/MetaMask/eslint-config#readme",
   "bugs": {

--- a/packages/jest/CHANGELOG.md
+++ b/packages/jest/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [15.0.1] [BACKPORT]
+
 ### Fixed
 
 - Allow import from CommonJS ([#453](https://github.com/MetaMask/eslint-config/pull/453))
@@ -132,7 +134,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - To continue extending this config, install this package and update your `.eslintrc.js` `extends` array to include `@metamask/eslint-config-jest` instead of `@metamask/eslint-config/jest`.
 - Update `eslint` and other ESLint peer dependencies ([#151](https://github.com/MetaMask/eslint-config/pull/151))
 
-[Unreleased]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-jest@15.0.0...HEAD
+[Unreleased]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-jest@15.0.1...HEAD
+[15.0.1]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-jest@15.0.0...@metamask/eslint-config-jest@15.0.1
 [15.0.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-jest@14.1.0...@metamask/eslint-config-jest@15.0.0
 [14.1.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-jest@14.0.0...@metamask/eslint-config-jest@14.1.0
 [14.0.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-jest@13.0.0...@metamask/eslint-config-jest@14.0.0

--- a/packages/jest/CHANGELOG.md
+++ b/packages/jest/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Allow import from CommonJS ([#453](https://github.com/MetaMask/eslint-config/pull/453))
+
 ## [15.0.0]
 
 ### Changed

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -14,10 +14,8 @@
   "type": "module",
   "exports": {
     ".": {
-      "import": {
-        "types": "./src/index.d.mts",
-        "default": "./src/index.mjs"
-      }
+      "types": "./src/index.d.mts",
+      "default": "./src/index.mjs"
     }
   },
   "main": "./src/index.mjs",

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/eslint-config-jest",
-  "version": "15.0.0",
+  "version": "15.0.1",
   "description": "Shareable MetaMask ESLint config for Jest.",
   "homepage": "https://github.com/MetaMask/eslint-config#readme",
   "bugs": {

--- a/packages/mocha/CHANGELOG.md
+++ b/packages/mocha/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [15.0.1] [BACKPORT]
+
 ### Fixed
 
 - Allow import from CommonJS ([#453](https://github.com/MetaMask/eslint-config/pull/453))
@@ -119,7 +121,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - To continue extending this config, install this package and update your `.eslintrc.js` `extends` array to include `@metamask/eslint-config-mocha` instead of `@metamask/eslint-config/mocha`.
 - Update `eslint` and other ESLint peer dependencies ([#151](https://github.com/MetaMask/eslint-config/pull/151))
 
-[Unreleased]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-mocha@15.0.0...HEAD
+[Unreleased]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-mocha@15.0.1...HEAD
+[15.0.1]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-mocha@15.0.0...@metamask/eslint-config-mocha@15.0.1
 [15.0.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-mocha@14.0.0...@metamask/eslint-config-mocha@15.0.0
 [14.0.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-mocha@13.0.0...@metamask/eslint-config-mocha@14.0.0
 [13.0.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-mocha@12.1.0...@metamask/eslint-config-mocha@13.0.0

--- a/packages/mocha/CHANGELOG.md
+++ b/packages/mocha/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Allow import from CommonJS ([#453](https://github.com/MetaMask/eslint-config/pull/453))
+
 ## [15.0.0]
 
 ### Changed

--- a/packages/mocha/package.json
+++ b/packages/mocha/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/eslint-config-mocha",
-  "version": "15.0.0",
+  "version": "15.0.1",
   "description": "Shareable MetaMask ESLint config for Mocha.",
   "homepage": "https://github.com/MetaMask/eslint-config#readme",
   "bugs": {

--- a/packages/mocha/package.json
+++ b/packages/mocha/package.json
@@ -14,10 +14,8 @@
   "type": "module",
   "exports": {
     ".": {
-      "import": {
-        "types": "./src/index.d.mts",
-        "default": "./src/index.mjs"
-      }
+      "types": "./src/index.d.mts",
+      "default": "./src/index.mjs"
     }
   },
   "main": "./src/index.mjs",

--- a/packages/nodejs/CHANGELOG.md
+++ b/packages/nodejs/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Allow import from CommonJS ([#453](https://github.com/MetaMask/eslint-config/pull/453))
+
 ## [15.0.0]
 
 ### Changed

--- a/packages/nodejs/CHANGELOG.md
+++ b/packages/nodejs/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [15.0.1] [BACKPORT]
+
 ### Fixed
 
 - Allow import from CommonJS ([#453](https://github.com/MetaMask/eslint-config/pull/453))
@@ -133,7 +135,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - To continue extending this config, install this package and update your `.eslintrc.js` `extends` array to include `@metamask/eslint-config-nodejs` instead of `@metamask/eslint-config/nodejs`.
 - Update `eslint` and other ESLint peer dependencies ([#151](https://github.com/MetaMask/eslint-config/pull/151))
 
-[Unreleased]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-nodejs@15.0.0...HEAD
+[Unreleased]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-nodejs@15.0.1...HEAD
+[15.0.1]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-nodejs@15.0.0...@metamask/eslint-config-nodejs@15.0.1
 [15.0.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-nodejs@14.0.0...@metamask/eslint-config-nodejs@15.0.0
 [14.0.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-nodejs@13.0.0...@metamask/eslint-config-nodejs@14.0.0
 [13.0.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-nodejs@12.1.0...@metamask/eslint-config-nodejs@13.0.0

--- a/packages/nodejs/package.json
+++ b/packages/nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/eslint-config-nodejs",
-  "version": "15.0.0",
+  "version": "15.0.1",
   "description": "Shareable MetaMask ESLint config for Node.js.",
   "homepage": "https://github.com/MetaMask/eslint-config#readme",
   "bugs": {

--- a/packages/nodejs/package.json
+++ b/packages/nodejs/package.json
@@ -14,10 +14,8 @@
   "type": "module",
   "exports": {
     ".": {
-      "import": {
-        "types": "./src/index.d.mts",
-        "default": "./src/index.mjs"
-      }
+      "types": "./src/index.d.mts",
+      "default": "./src/index.mjs"
     }
   },
   "main": "./src/index.mjs",

--- a/packages/typescript/CHANGELOG.md
+++ b/packages/typescript/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Allow import from CommonJS ([#453](https://github.com/MetaMask/eslint-config/pull/453))
+
 ## [15.0.0]
 
 ### Changed

--- a/packages/typescript/CHANGELOG.md
+++ b/packages/typescript/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [15.0.1] [BACKPORT]
+
 ### Fixed
 
 - Allow import from CommonJS ([#453](https://github.com/MetaMask/eslint-config/pull/453))
@@ -215,7 +217,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - To continue extending this config, install this package and update your `.eslintrc.js` `extends` array to include `@metamask/eslint-config-typescript` instead of `@metamask/eslint-config/typescript`.
 - Update `eslint` and other ESLint peer dependencies ([#151](https://github.com/MetaMask/eslint-config/pull/151))
 
-[Unreleased]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-typescript@15.0.0...HEAD
+[Unreleased]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-typescript@15.0.1...HEAD
+[15.0.1]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-typescript@15.0.0...@metamask/eslint-config-typescript@15.0.1
 [15.0.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-typescript@14.1.0...@metamask/eslint-config-typescript@15.0.0
 [14.1.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-typescript@14.0.0...@metamask/eslint-config-typescript@14.1.0
 [14.0.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-typescript@13.0.0...@metamask/eslint-config-typescript@14.0.0

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -14,10 +14,8 @@
   "type": "module",
   "exports": {
     ".": {
-      "import": {
-        "types": "./src/index.d.mts",
-        "default": "./src/index.mjs"
-      }
+      "types": "./src/index.d.mts",
+      "default": "./src/index.mjs"
     }
   },
   "main": "./src/index.mjs",

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/eslint-config-typescript",
-  "version": "15.0.0",
+  "version": "15.0.1",
   "description": "Shareable MetaMask ESLint config for TypeScript.",
   "homepage": "https://github.com/MetaMask/eslint-config#readme",
   "bugs": {

--- a/packages/vitest/CHANGELOG.md
+++ b/packages/vitest/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [15.0.1] [BACKPORT]
+
 ### Fixed
 
 - Allow import from CommonJS ([#453](https://github.com/MetaMask/eslint-config/pull/453))
@@ -26,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - This config is based on the `@metamask/eslint-config-jest` config, but uses
     the Vitest plugin instead of Jest.
 
-[Unreleased]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-vitest@15.0.0...HEAD
+[Unreleased]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-vitest@15.0.1...HEAD
+[15.0.1]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-vitest@15.0.0...@metamask/eslint-config-vitest@15.0.1
 [15.0.0]: https://github.com/MetaMask/eslint-config/compare/@metamask/eslint-config-vitest@1.0.0...@metamask/eslint-config-vitest@15.0.0
 [1.0.0]: https://github.com/MetaMask/eslint-config/releases/tag/@metamask/eslint-config-vitest@1.0.0

--- a/packages/vitest/CHANGELOG.md
+++ b/packages/vitest/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Allow import from CommonJS ([#453](https://github.com/MetaMask/eslint-config/pull/453))
+
 ## [15.0.0]
 
 ### Changed

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -14,10 +14,8 @@
   "type": "module",
   "exports": {
     ".": {
-      "import": {
-        "types": "./src/index.d.mts",
-        "default": "./src/index.mjs"
-      }
+      "types": "./src/index.d.mts",
+      "default": "./src/index.mjs"
     }
   },
   "main": "./src/index.mjs",

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/eslint-config-vitest",
-  "version": "15.0.0",
+  "version": "15.0.1",
   "description": "Shareable MetaMask ESLint config for Vitest.",
   "homepage": "https://github.com/MetaMask/eslint-config#readme",
   "bugs": {


### PR DESCRIPTION
This is a release candidate for v15.0.1, a backport release for v15.x

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging-only change with no lint rule or runtime logic edits; risk is limited to module resolution behavior for consumers on 15.0.0.
> 
> **Overview**
> **v15.0.1** is a patch backport across all `@metamask/eslint-config*` workspace packages (root and eight published configs).
> 
> The functional change is in each package’s **`exports`** map: the entry point no longer uses an **`import`-only** nested condition. **`types`** and **`default`** now sit directly on `"."`, so Node can resolve the published **`index.mjs`** for consumers that load the package from **CommonJS** (e.g. legacy `eslint.config.js` or tooling that `require`s the config), addressing [#453](https://github.com/MetaMask/eslint-config/pull/453).
> 
> Versions move **15.0.0 → 15.0.1**; changelogs record the fix under **[15.0.1] [BACKPORT]** with updated compare links. No ESLint rule or source config changes are in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3ad788ce3c182dca0a592c48663de532a75e6b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->